### PR TITLE
Fix broken link on breadcrumb

### DIFF
--- a/src/pages/experiments/[experimentId]/data-exploration/components/header/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/header/index.jsx
@@ -80,8 +80,8 @@ const Header = (props) => {
       breadcrumbName: 'Experiments',
     },
     {
-      path: '[experimentId]',
-      params: data.experimentId,
+      path: '[experimentId]/data-exploration',
+      params: [data.experimentId, 'data-exploration'].join('/'),
       breadcrumbName: data.experimentName,
     },
     {
@@ -118,7 +118,6 @@ const Header = (props) => {
     </>
   );
 };
-
 
 Header.propTypes = {
   experimentId: PropTypes.string.isRequired,

--- a/src/pages/experiments/[experimentId]/plots-and-tables/components/Header.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/components/Header.jsx
@@ -80,8 +80,8 @@ const Header = (props) => {
       breadcrumbName: 'Experiments',
     },
     {
-      path: '[experimentId]',
-      params: data.experimentId,
+      path: '[experimentId]/plots-and-tables',
+      params: [data.experimentId, 'plots-and-tables'].join('/'),
       breadcrumbName: data.experimentName,
     },
     {


### PR DESCRIPTION
The links on the breadcrumbs were not working, because they were not referencing the full url.