### PR TITLE
Fix/cell sets tool default to eye view

### DIFF
--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/hierarchical-tree/HierarchicalTree.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/hierarchical-tree/HierarchicalTree.test.jsx
@@ -192,33 +192,23 @@ describe('HierarchicalTree', () => {
     expect(mockOnHierarchyUpdate).toHaveBeenCalledTimes(0);
   });
 
-  it('when no tree data, no keys are checked by default', () => {
-    const treeData = [];
+  it('tree data is not checked by default', () => {
+    const treeData = [{ key: 'louvain' }];
     const mockOnCheck = jest.fn();
     mount(
-      <HierarchicalTree treeData={treeData} onCheck={mockOnCheck} />,
+      <HierarchicalTree treeData={treeData} onCheck={mockOnCheck}/>,
     );
     expect(mockOnCheck).toHaveBeenCalledTimes(0);
   });
 
-  it('correct keys in tree data with no children are checked by default', () => {
-    const treeData = [{ key: 'louvain' }];
-    const mockOnCheck = jest.fn();
-    mount(
-      <HierarchicalTree treeData={treeData} onCheck={mockOnCheck} />,
-    );
-    expect(mockOnCheck).toHaveBeenCalledTimes(1);
-    expect(mockOnCheck).toHaveBeenCalledWith(['louvain']);
-  });
-
-  it('correct keys in tree data with children are checked by default', () => {
+  it('tree data can be checked by default by passing defaultCheckedKeys prop', () => {
     const treeData = [
       { key: 'louvain', children: [{ key: 'one' }, { key: 'two' }, { key: 'three' }] },
       { key: 'another-set', children: [{ key: 'four' }, { key: 'five' }, { key: 'six' }] },
     ];
     const mockOnCheck = jest.fn();
     mount(
-      <HierarchicalTree treeData={treeData} onCheck={mockOnCheck} />,
+      <HierarchicalTree treeData={treeData} defaultCheckedKeys={['louvain', 'one', 'two', 'three']} onCheck={mockOnCheck} />,
     );
     expect(mockOnCheck).toHaveBeenCalledTimes(1);
     expect(mockOnCheck).toHaveBeenCalledWith(['louvain', 'one', 'two', 'three']);

--- a/src/__test__/redux/reducers/__snapshots__/cellInfoReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/cellInfoReducer.test.js.snap
@@ -23,8 +23,8 @@ Object {
   "cellName": "C1",
   "expression": 1,
   "focus": Object {
-    "key": null,
-    "store": null,
+    "key": "louvain",
+    "store": "cellSets",
   },
   "geneName": "G1",
 }

--- a/src/__test__/redux/reducers/cellInfoReducer.test.js
+++ b/src/__test__/redux/reducers/cellInfoReducer.test.js
@@ -28,6 +28,15 @@ describe('cellInfoReducer', () => {
 
 */
 
+// Unfocused state
+const unfocusedState = {
+  focus:
+    {
+      store: null,
+      key: null,
+    },
+};
+
 describe('cellInfoReducer', () => {
   it('Reduces identical state on unknown action', () => expect(
     cellInfoReducer(undefined, {
@@ -71,7 +80,7 @@ describe('cellInfoReducer', () => {
       type: CELL_INFO_UNFOCUS,
     });
 
-    expect(newState.focus).toEqual(initialState.focus);
+    expect(newState.focus).toEqual(unfocusedState.focus);
     expect(newState).toMatchSnapshot();
   });
 });

--- a/src/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.jsx
@@ -160,6 +160,7 @@ const CellSetsTool = (props) => {
               onHierarchyUpdate={onHierarchyUpdate}
               defaultExpandAll
               showHideButton
+              defaultCheckedKeys={selected}
             />
           </TabPane>
           <TabPane tab='Metadata' key='metadataCategorical'>
@@ -174,6 +175,7 @@ const CellSetsTool = (props) => {
                 onHierarchyUpdate={onHierarchyUpdate}
                 defaultExpandAll
                 showHideButton
+                defaultCheckedKeys={selected}
               />
             )
               : (

--- a/src/pages/experiments/[experimentId]/data-exploration/components/embedding/Embedding.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/embedding/Embedding.jsx
@@ -199,7 +199,7 @@ const Embedding = (props) => {
       return (
         <div>
           <label htmlFor='cell set name'>
-            <strong>{cellSetProperties[focusData.key].name}</strong>
+            <strong>{cellSetProperties[focusData.key] ? cellSetProperties[focusData.key].name : ''}</strong>
           </label>
         </div>
       );

--- a/src/pages/experiments/[experimentId]/data-exploration/components/hierarchical-tree/HierarchicalTree.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/hierarchical-tree/HierarchicalTree.jsx
@@ -19,6 +19,7 @@ const HierarchicalTree = (props) => {
   const {
     onCheck: propOnCheck,
     onNodeUpdate: propOnNodeUpdate,
+    defaultCheckedKeys: propDefaultCheckedKeys,
     treeData,
     store,
     experimentId,
@@ -27,17 +28,7 @@ const HierarchicalTree = (props) => {
   } = props;
 
   const [autoExpandParent, setAutoExpandParent] = useState(true);
-
-  // by default, the first entry of treeData and all its children is checked
-  const getDefaultCheckedKeys = () => {
-    if (!treeData || treeData.length === 0) return [];
-    const chKeys = [treeData[0].key];
-    if (!treeData[0].children) return chKeys;
-    treeData[0].children.filter((child) => chKeys.push(child.key));
-    return chKeys;
-  };
-
-  const [checkedKeys, setCheckedKeys] = useState(getDefaultCheckedKeys());
+  const [checkedKeys, setCheckedKeys] = useState(propDefaultCheckedKeys);
 
   useEffect(() => {
     if (checkedKeys.length > 0) {

--- a/src/pages/experiments/[experimentId]/data-exploration/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/index.jsx
@@ -14,7 +14,6 @@ import Embedding from './components/embedding/Embedding';
 import HeatmapPlot from './components/heatmap/HeatmapPlot';
 import HeatmapSettings from './components/heatmap/HeatmapSettings';
 import { updateLayout } from '../../../../redux/actions/layout';
-import { setCellInfoFocus } from '../../../../redux/actions/cellInfo';
 import getApiEndpoint from '../../../../utils/apiEndpoint';
 import { getFromApiExpectOK } from '../../../../utils/cacheRequest';
 import PreloadContent from '../../../../components/PreloadContent';
@@ -40,22 +39,12 @@ const ExplorationViewPage = () => {
   const router = useRouter();
   const { experimentId } = router.query;
   const layout = useSelector((state) => state.layout);
-  const embeddingState = useSelector((state) => state.embeddings)
-  const cellSetsState = useSelector((state) => state.cellSets)
   const { windows, panel } = layout;
   const [selectedTab, setSelectedTab] = useState(panel);
 
   useEffect(() => {
     setSelectedTab(panel);
-
-    // Toggle Louvain color when embedding and cellSets finish loading
-    if(embeddingState.umap !== undefined) {
-      if(!embeddingState.umap.loading && !cellSetsState.loading) {
-        dispatch(setCellInfoFocus(experimentId,'cellSets', 'louvain'))
-      }
-    }
-
-  }, [panel, embeddingState, cellSetsState]);
+  }, [panel]);
 
   const { data, error } = useSWR(`${getApiEndpoint()}/v1/experiments/${experimentId}`, getFromApiExpectOK);
 

--- a/src/pages/experiments/[experimentId]/data-exploration/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/index.jsx
@@ -14,6 +14,7 @@ import Embedding from './components/embedding/Embedding';
 import HeatmapPlot from './components/heatmap/HeatmapPlot';
 import HeatmapSettings from './components/heatmap/HeatmapSettings';
 import { updateLayout } from '../../../../redux/actions/layout';
+import { setCellInfoFocus } from '../../../../redux/actions/cellInfo';
 import getApiEndpoint from '../../../../utils/apiEndpoint';
 import { getFromApiExpectOK } from '../../../../utils/cacheRequest';
 import PreloadContent from '../../../../components/PreloadContent';
@@ -39,12 +40,22 @@ const ExplorationViewPage = () => {
   const router = useRouter();
   const { experimentId } = router.query;
   const layout = useSelector((state) => state.layout);
+  const embeddingState = useSelector((state) => state.embeddings)
+  const cellSetsState = useSelector((state) => state.cellSets)
   const { windows, panel } = layout;
   const [selectedTab, setSelectedTab] = useState(panel);
 
   useEffect(() => {
     setSelectedTab(panel);
-  }, [panel]);
+
+    // Toggle Louvain color when embedding and cellSets finish loading
+    if(embeddingState.umap !== undefined) {
+      if(!embeddingState.umap.loading && !cellSetsState.loading) {
+        dispatch(setCellInfoFocus(experimentId,'cellSets', 'louvain'))
+      }
+    }
+
+  }, [panel, embeddingState, cellSetsState]);
 
   const { data, error } = useSWR(`${getApiEndpoint()}/v1/experiments/${experimentId}`, getFromApiExpectOK);
 

--- a/src/pages/experiments/[experimentId]/data-exploration/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/index.jsx
@@ -90,7 +90,7 @@ const ExplorationViewPage = () => {
         </Tabs>
       ),
     },
-    'Cell sets': {
+    'Data Management': {
       toolbarControls: [<RemoveButton />],
       component: (width, height) => <CellSetsTool experimentId={experimentId} width={width} height={height} />,
     },

--- a/src/redux/reducers/cellInfo/cellInfoUnfocus.js
+++ b/src/redux/reducers/cellInfo/cellInfoUnfocus.js
@@ -1,9 +1,8 @@
-import initialState from './initialState';
-
 const cellInfoUnfocus = (state) => ({
   ...state,
   focus: {
-    ...initialState.focus,
+    store: null,
+    key: null,
   },
 });
 

--- a/src/redux/reducers/cellInfo/initialState.js
+++ b/src/redux/reducers/cellInfo/initialState.js
@@ -1,7 +1,7 @@
 const initialState = {
   focus: {
-    store: null,
-    key: null,
+    store: 'cellSets',
+    key: 'louvain',
   },
 };
 

--- a/src/redux/reducers/layout/initialState.js
+++ b/src/redux/reducers/layout/initialState.js
@@ -3,7 +3,7 @@ const initialState = {
     direction: 'row',
     first: {
       first: {
-        first: 'UMAP Embedding', second: 'Cell sets', direction: 'row', splitPercentage: 60,
+        first: 'UMAP Embedding', second: 'Data Management', direction: 'row', splitPercentage: 60,
       },
       second: 'Heatmap',
       direction: 'column',


### PR DESCRIPTION
# Background

Functional change to the use of checkboxes in the Cell Sets management tool requires changes to be made to the code.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-412

#### Link to staging deployment URL 
https://ui-7c87uih1k8g1baaew4sg791t4o.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

- `HierarchyTree` no longer depend on `treeData` to check checkboxes. Checboxes are checked by passing a list of keys to the `defaultCheckedKeys` prop
- 'Cell sets' panel is changed to 'Data Management' as in the mock up (https://docs.google.com/presentation/d/1-6mtMrZF14GRAYtLjh3F7FmhyE4o5WRpwyxt5gISGDo/edit?usp=sharing)

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] Unit tests written
- [X] Tested locally with Inframock
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [X] Approved by a member of the core engineering team
- [x] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [X] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
