### PR TITLE
Feature/cell set complement

### DIFF
--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.test.jsx
@@ -154,8 +154,8 @@ describe('CellSetsTool', () => {
 
     const operations = component.find(CellSetOperation);
 
-    // There should be two operations rendered
-    expect(operations.length).toEqual(2);
+    // There should be three operations rendered (union, intersection, complement)
+    expect(operations.length).toEqual(3);
   });
 
   it('cell set operations should work appropriately for unions', () => {
@@ -233,6 +233,47 @@ describe('CellSetsTool', () => {
         // Should create the appropriate intersection set.
         const createAction = store.getActions()[1];
         expect(createAction.payload.cellIds).toEqual(new Set([2]));
+      }
+    });
+
+    // We should have found the union operation.
+    expect.hasAssertions();
+  });
+
+  it('cell set operations should work appropriately for complement', () => {
+    const store = mockStore(
+      {
+        ...storeState,
+        cellSets: {
+          ...storeState.cellSets,
+          selected: [
+            ...storeState.cellSets.selected, 'scratchpad-a', 'cluster-c',
+          ],
+        },
+      },
+    );
+
+    const component = mount(
+      <Provider store={store}>
+        <CellSetsTool
+          experimentId='1234'
+          width={50}
+          height={50}
+        />
+      </Provider>,
+    );
+
+    component.find('CellSetOperation').forEach((node) => {
+      const { helpTitle, onCreate } = node.props();
+
+      if (helpTitle.includes('complement')) {
+        // found the union operation, now execute the callback
+        onCreate('complement cluster', '#ff00ff');
+        expect(store.getActions().length).toEqual(3);
+
+        // Should create the appropriate intersection set.
+        const createAction = store.getActions()[1];
+        expect(createAction.payload.cellIds).toEqual(new Set([1, 4]));
       }
     });
 

--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.test.jsx
@@ -184,7 +184,7 @@ describe('CellSetsTool', () => {
     component.find('CellSetOperation').forEach((node) => {
       const { helpTitle, onCreate } = node.props();
 
-      if (helpTitle.includes('Combine')) {
+      if (helpTitle.includes('combining')) {
         // found the union operation, now execute the callback
         onCreate('union cluster', '#ff00ff');
         expect(store.getActions().length).toEqual(3);

--- a/src/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/cell-sets-tool/CellSetsTool.jsx
@@ -8,7 +8,7 @@ import {
   Typography, Empty, Button, Alert,
 } from 'antd';
 
-import { MergeCellsOutlined, SplitCellsOutlined } from '@ant-design/icons';
+import { BlockOutlined, MergeCellsOutlined, SplitCellsOutlined } from '@ant-design/icons';
 
 import { Element, animateScroll } from 'react-scroll';
 import HierarchicalTree from '../hierarchical-tree/HierarchicalTree';
@@ -26,7 +26,7 @@ import isBrowser from '../../../../../../utils/environment';
 import messages from '../../../../../../components/notification/messages';
 import PlatformError from '../../../../../../components/PlatformError';
 import CellSetOperation from './CellSetOperation';
-import { union, intersection } from '../../../../../../utils/cellSetOperations';
+import { union, intersection, complement } from '../../../../../../utils/cellSetOperations';
 
 const { Text } = Typography;
 
@@ -105,18 +105,25 @@ const CellSetsTool = (props) => {
       operations = (
         <Space>
           <CellSetOperation
-            icon={<SplitCellsOutlined />}
-            onCreate={(name, color) => {
-              dispatch(createCellSet(experimentId, name, color, intersection(selected, properties)));
-            }}
-            helpTitle='Create intersection of selected'
-          />
-          <CellSetOperation
             icon={<MergeCellsOutlined />}
             onCreate={(name, color) => {
               dispatch(createCellSet(experimentId, name, color, union(selected, properties)));
             }}
-            helpTitle='Combine selected'
+            helpTitle='Create new cell set by combining selected sets'
+          />
+          <CellSetOperation
+            icon={<BlockOutlined />}
+            onCreate={(name, color) => {
+              dispatch(createCellSet(experimentId, name, color, intersection(selected, properties)));
+            }}
+            helpTitle='Create new cell set from intersection of selected sets'
+          />
+          <CellSetOperation
+            icon={<SplitCellsOutlined />}
+            onCreate={(name, color) => {
+              dispatch(createCellSet(experimentId, name, color, complement(selected, properties)));
+            }}
+            helpTitle='Create new cell set from the complement of the selected sets'
           />
           <Text type='primary'>
             {numSelected}

--- a/src/utils/cellSetOperations.js
+++ b/src/utils/cellSetOperations.js
@@ -46,6 +46,7 @@ const complement = (listOfSets, properties) => {
     (acc, curr) => new Set([...acc, ...curr]),
   );
 
+  // All cells are assumed to be included in at least 1 cluster
   const complementSet = Object.values(properties).map(
     (cluster) => cluster.cellIds,
   ).filter(

--- a/src/utils/cellSetOperations.js
+++ b/src/utils/cellSetOperations.js
@@ -33,4 +33,32 @@ const intersection = (listOfSets, properties) => {
   return intersectionSet;
 };
 
-export { union, intersection };
+const complement = (listOfSets, properties) => {
+  if (!listOfSets) {
+    return new Set();
+  }
+
+  const selectedCells = listOfSets.map(
+    (key) => properties[key]?.cellIds || null,
+  ).filter(
+    (set) => set && set.size > 0,
+  ).reduce(
+    (acc, curr) => new Set([...acc, ...curr]),
+  );
+
+  const complementSet = Object.values(properties).map(
+    (cluster) => cluster.cellIds,
+  ).filter(
+    (set) => set && set.size > 0,
+  ).reduce(
+    (acc, curr) => new Set([...acc, ...curr]),
+  );
+
+  if (selectedCells.size > 0) {
+    selectedCells.forEach((x) => { complementSet.delete(x); });
+  }
+
+  return complementSet;
+};
+
+export { union, intersection, complement };


### PR DESCRIPTION
# Background

Need to add functionality for selecting complement of selected cells

#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-409

#### Link to staging deployment URL 

https://ui-r6ibd6bbxcbp3endub1yopiauo.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N/A

#### Anything else the reviewers should know about the changes here

- Added a new test suite to check for the complementation function
- Renamed operation help titles according to mockup
- Swap icon for complement and intersection (Vicky said ok)

# Changes
### Code changes

- Added new CellSetOperation

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] Unit tests written
- [X] Tested locally with Inframock
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [X] Photo of a cute animal attached to this PR

<img src="https://user-images.githubusercontent.com/2862362/104017940-94c47700-51eb-11eb-9aec-426f76be631e.png" height="300">
