### PR TITLE
Hide or show legend on the heatmap.

### DIFF
--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.test.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { configure, mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import { act } from 'react-dom/test-utils';
+import Adapter from 'enzyme-adapter-react-16';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { Radio } from 'antd';
+
+import { UPDATE_CONFIG } from '../../../../../../../redux/actionTypes/componentConfig';
+import HeatmapLegendVisibilitySettings from '../../../../../../../pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings';
+
+const initialState = {
+  cellSets: {
+    // cellSets', 'metadataCategorical
+    hierarchy: [
+      {
+        key: 'louvain',
+        children: [
+          {
+            key: 'louvain-0',
+          },
+          {
+            key: 'louvain-1',
+          },
+        ],
+      },
+      {
+        key: 'sample',
+        children: [
+          {
+            key: 'control',
+          },
+          {
+            key: 'treated',
+          },
+        ],
+      },
+    ],
+    properties: {
+      louvain: {
+        type: 'cellSets',
+        name: 'louvain clusters',
+      },
+      'louvain-0': {
+        name: 'louvain 0',
+        cellIds: [5, 6, 7],
+      },
+      'louvain-1': {
+        name: 'louvain 1',
+        cellIds: [1, 2, 3],
+      },
+      sample: {
+        type: 'metadataCategorical',
+        name: 'Sample',
+      },
+      control: {
+        name: 'control',
+        cellIds: [5, 6, 7],
+      },
+      treated: {
+        name: 'treated',
+        cellIds: [1, 2, 3],
+      },
+    },
+  },
+  cellInfo: {},
+  componentConfig: {
+    interactiveHeatmap: {
+      config: {
+        groupedTrack: 'sample',
+        selectedTracks: ['louvain'],
+        legendIsVisible: true,
+      },
+    },
+  },
+};
+
+const mockStore = configureMockStore([thunk]);
+configure({ adapter: new Adapter() });
+
+const eventStub = {
+  stopPropagation: () => { },
+};
+
+describe('HeatmapLegendVisibilitySettings', () => {
+  let component, store, buttons;
+
+  afterEach(() => {
+    component.unmount();
+  });
+
+  beforeEach(() => {
+    store = mockStore({
+      ...initialState,
+    });
+
+    component = mount(
+      <Provider store={store}>
+        {/* ask if experimentId='123' width={200} height={200} are necessary in HeatmapGroupBySettings */}
+        <HeatmapLegendVisibilitySettings experimentId='123' width={200} height={200} />
+      </Provider>,
+    );
+  });
+
+  it('renders correctly', () => {
+    const buttons = component.find('Radio');
+
+    // Should be rendered.
+    expect(component.find('HeatmapLegendVisibilitySettings').length).toEqual(1);
+
+    // With two buttons.
+    expect(buttons.length).toEqual(2);
+
+    // With the right keys.
+    expect(buttons.at(0).props().value).toEqual(true);
+    expect(buttons.at(1).props().value).toEqual(false);
+
+    // The selected one should be `Show`.
+    expect(component.find(Radio.Group).props().value).toEqual(true);
+  });
+
+  it('responds correctly to clicking to hide', () => {
+    // Click hide button
+    act(() => {
+      component.find('ForwardRef').props().onChange({ "target": { "value": false } });
+    });
+
+    let storeActions = store.getActions();
+
+    // Only one action was dispatched
+    expect(storeActions.length).toEqual(1);
+
+    let action = storeActions[0];
+    let configChange = action.payload.configChange;
+
+    // Of the correct type
+    expect(action.type).toBe(UPDATE_CONFIG);
+
+    // With the correct property
+    expect(configChange).toHaveProperty("legendIsVisible", false);
+
+    // QUESTION: Should I check that the object doesn't have any other property? (example: check size is 1)
+  });
+
+  it('responds correctly to clicking to show', () => {
+    // Click show button
+    act(() => {
+      component.find('ForwardRef').props().onChange({ "target": { "value": true } });
+    });
+
+    let storeActions = store.getActions();
+
+    // Only one action was dispatched
+    expect(storeActions.length).toEqual(1);
+
+    let action = storeActions[0];
+    let configChange = action.payload.configChange;
+
+    // Of the correct type
+    expect(action.type).toBe(UPDATE_CONFIG);
+
+    // With the correct property
+    expect(configChange).toHaveProperty("legendIsVisible", true);
+  });
+});

--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.test.jsx
@@ -12,7 +12,6 @@ import HeatmapLegendVisibilitySettings from '../../../../../../../pages/experime
 
 const initialState = {
   cellSets: {
-    // cellSets', 'metadataCategorical
     hierarchy: [
       {
         key: 'louvain',
@@ -79,10 +78,6 @@ const initialState = {
 const mockStore = configureMockStore([thunk]);
 configure({ adapter: new Adapter() });
 
-const eventStub = {
-  stopPropagation: () => { },
-};
-
 describe('HeatmapLegendVisibilitySettings', () => {
   let component, store, buttons;
 
@@ -97,8 +92,7 @@ describe('HeatmapLegendVisibilitySettings', () => {
 
     component = mount(
       <Provider store={store}>
-        {/* ask if experimentId='123' width={200} height={200} are necessary in HeatmapGroupBySettings */}
-        <HeatmapLegendVisibilitySettings experimentId='123' width={200} height={200} />
+        <HeatmapLegendVisibilitySettings />
       </Provider>,
     );
   });

--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.test.jsx
@@ -117,7 +117,7 @@ describe('HeatmapLegendVisibilitySettings', () => {
   it('responds correctly to clicking to hide', () => {
     // Click hide button
     act(() => {
-      component.find('ForwardRef').props().onChange({ "target": { "value": false } });
+      component.find(Radio.Group).props().onChange({ "target": { "value": false } });
     });
 
     let storeActions = store.getActions();
@@ -133,14 +133,13 @@ describe('HeatmapLegendVisibilitySettings', () => {
 
     // With the correct property
     expect(configChange).toHaveProperty("legendIsVisible", false);
-
-    // QUESTION: Should I check that the object doesn't have any other property? (example: check size is 1)
+    expect(configChange).toMatchSnapshot();
   });
 
   it('responds correctly to clicking to show', () => {
     // Click show button
     act(() => {
-      component.find('ForwardRef').props().onChange({ "target": { "value": true } });
+      component.find(Radio.Group).props().onChange({ "target": { "value": true } });
     });
 
     let storeActions = store.getActions();
@@ -156,5 +155,6 @@ describe('HeatmapLegendVisibilitySettings', () => {
 
     // With the correct property
     expect(configChange).toHaveProperty("legendIsVisible", true);
+    expect(configChange).toMatchSnapshot();
   });
 });

--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/__snapshots__/HeatmapLegendVisibilitySettings.test.jsx.snap
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/__snapshots__/HeatmapLegendVisibilitySettings.test.jsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeatmapLegendVisibilitySettings responds correctly to clicking to hide 1`] = `
+Object {
+  "legendIsVisible": false,
+}
+`;
+
+exports[`HeatmapLegendVisibilitySettings responds correctly to clicking to show 1`] = `
+Object {
+  "legendIsVisible": true,
+}
+`;

--- a/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.jsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { Radio } from 'antd';
 import { updatePlotConfig } from '../../../../../../redux/actions/componentConfig';
 
 const HeatmapLegendVisibilitySettings = () => {
   const dispatch = useDispatch();
 
-  const [showLegend, setShowLegend] = useState(true);
+  const heatmapSettings = useSelector((state) => state.componentConfig.interactiveHeatmap?.config) || {};
+
+  const [showLegend, setShowLegend] = useState(heatmapSettings.legendIsVisible);
 
   const radioStyle = {
     display: 'block',

--- a/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapLegendVisibilitySettings.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { Radio } from 'antd';
+import { updatePlotConfig } from '../../../../../../redux/actions/componentConfig';
+
+const HeatmapLegendVisibilitySettings = () => {
+  const dispatch = useDispatch();
+
+  const [showLegend, setShowLegend] = useState(true);
+
+  const radioStyle = {
+    display: 'block',
+    padding: '5px',
+    marginLeft: '0px',
+  };
+
+  const changelegend = (e) => {
+    dispatch(
+      updatePlotConfig('interactiveHeatmap', {
+        legendIsVisible: e.target.value,
+      })
+    );
+
+    setShowLegend(e.target.value);
+  };
+
+  return (
+    <Radio.Group value={showLegend} onChange={changelegend}>
+      <Radio key='1' style={radioStyle} value>Show</Radio>
+      <Radio key='2' style={radioStyle} value={false}>Hide</Radio>
+    </Radio.Group>
+  );
+
+};
+
+HeatmapLegendVisibilitySettings.defaultProps = {
+};
+
+HeatmapLegendVisibilitySettings.propTypes = {
+};
+
+export default HeatmapLegendVisibilitySettings;

--- a/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
@@ -38,7 +38,7 @@ const HeatmapPlot = (props) => {
   const hidden = useSelector((state) => state.cellSets.hidden);
 
   const heatmapSettings = useSelector((state) => state.componentConfig.interactiveHeatmap?.config) || {};
-  const { selectedTracks, groupedTrack } = heatmapSettings;
+  const { selectedTracks, groupedTrack, legendIsVisible } = heatmapSettings;
 
   const { error } = expressionData;
   const viewError = useSelector((state) => state.genes.expression.views[COMPONENT_TYPE]?.error);
@@ -305,10 +305,13 @@ const HeatmapPlot = (props) => {
     );
   }
 
+  let specCopy = { ...spec };
+  specCopy.legends = legendIsVisible ? spec.legends : [];
+
   return (
     <div>
       <VegaHeatmap
-        spec={spec}
+        spec={specCopy}
         data={vegaData}
         showAxes={selectedGenes?.length <= 30}
         rowsNumber={selectedGenes.length}

--- a/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
@@ -29,6 +29,7 @@ const HeatmapPlot = (props) => {
   const loadingGenes = useSelector((state) => state.genes.expression.loading);
   const selectedGenes = useSelector((state) => state.genes.expression.views[COMPONENT_TYPE]?.data);
   const [vegaData, setVegaData] = useState(null);
+  const [vegaSpec, setVegaSpec] = useState(spec);
 
   const expressionData = useSelector((state) => state.genes.expression);
   const hoverCoordinates = useRef({});
@@ -56,6 +57,11 @@ const HeatmapPlot = (props) => {
 
     dispatch(loadComponentConfig(experimentId, 'interactiveHeatmap', 'interactiveHeatmap'));
   }, [heatmapSettings]);
+
+  useEffect(() => {
+    const legends = legendIsVisible ? spec.legends : [];
+    setVegaSpec({ ...spec, legends });
+  }, [legendIsVisible]);
 
   useEffect(() => {
     if (!selectedGenes || selectedGenes.length === 0) {
@@ -305,13 +311,10 @@ const HeatmapPlot = (props) => {
     );
   }
 
-  let specCopy = { ...spec };
-  specCopy.legends = legendIsVisible ? spec.legends : [];
-
   return (
     <div>
       <VegaHeatmap
-        spec={specCopy}
+        spec={vegaSpec}
         data={vegaData}
         showAxes={selectedGenes?.length <= 30}
         rowsNumber={selectedGenes.length}

--- a/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapSettings.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapSettings.jsx
@@ -7,6 +7,7 @@ import {
 } from 'antd';
 import HeatmapMetadataTrackSettings from './HeatmapMetadataTrackSettings';
 import HeatmapGroupBySettings from './HeatmapGroupBySettings';
+import HeatmapLegendVisibilitySettings from './HeatmapLegendVisibilitySettings';
 
 const { SubMenu, Item } = Menu;
 
@@ -16,9 +17,9 @@ const HeatmapSettings = () => {
       <Item key='expression-values' disabled>
         Expression values...
       </Item>
-      <Item key='toggle-legend' disabled>
-        Hide legend
-      </Item>
+      <SubMenu key='legend' title='Legend' icon={<></>}>
+        <HeatmapLegendVisibilitySettings />
+      </SubMenu>
       <SubMenu key='metadata-tracks' title='Metadata tracks...' icon={<></>}>
         <HeatmapMetadataTrackSettings />
       </SubMenu>

--- a/src/redux/reducers/componentConfig/initialState.js
+++ b/src/redux/reducers/componentConfig/initialState.js
@@ -176,6 +176,7 @@ const frequencyInitialConfig = {
 const interactiveHeatmapInitialConfig = {
   selectedTracks: ['louvain'],
   groupedTrack: 'louvain',
+  legendIsVisible: true,
 };
 
 const initialPlotConfigStates = {


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-418

#### Link to staging deployment URL 
https://ui-a5uby3hmayakcj3y8856yqc9gr.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes
Added functionality for the radio button in heatmap -> settings -> legend menu to show or hide the legend.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
