### PR TITLE
Add cell set loading hook to the Heatmap

### DIFF
--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.test.jsx
@@ -8,6 +8,8 @@ import { ExclamationCircleFilled } from '@ant-design/icons';
 import HeatmapPlot from '../../../../../../../pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot';
 import VegaHeatmap from '../../../../../../../pages/experiments/[experimentId]/data-exploration/components/heatmap/VegaHeatmap';
 
+import { CELL_SETS_LOADING } from '../../../../../../../redux/actionTypes/cellSets';
+
 jest.mock('localforage');
 jest.mock('../../../../../../../pages/experiments/[experimentId]/data-exploration/components/heatmap/VegaHeatmap');
 VegaHeatmap.mockImplementation(() => <div>Mocked Vega Heatmap</div>);
@@ -213,5 +215,31 @@ describe('HeatmapPlot', () => {
 
     expect(component.find('HeatmapPlot').length).toEqual(1);
     expect(component.find(ExclamationCircleFilled).length).toEqual(1);
+  });
+
+  it('dispatches loadCellSets action when no cell sets are in the store', () => {
+    const store = mockStore({
+      ...initialState,
+      cellSets: {
+        ...initialState.cellSets,
+        hierarchy: [],
+        properties: [],
+        loading: false,
+        error: true,
+      },
+    });
+
+    component = mount(
+      <Provider store={store}>
+        <HeatmapPlot experimentId='123' width={200} height={200} />
+      </Provider>,
+    );
+
+    expect(component.find('HeatmapPlot').length).toEqual(1);
+    expect(store.getActions().length).toEqual(1);
+    const [loadAction] = store.getActions();
+
+    expect(loadAction.type).toBe(CELL_SETS_LOADING);
+    expect(loadAction).toMatchSnapshot();
   });
 });

--- a/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/__snapshots__/HeatmapPlot.test.jsx.snap
+++ b/src/__test__/pages/experiments/[experimentId]/data-exploration/components/heatmap/__snapshots__/HeatmapPlot.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HeatmapPlot dispatches loadCellSets action when no cell sets are in the store 1`] = `
+Object {
+  "type": "cellSets/loading",
+}
+`;

--- a/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
@@ -12,6 +12,7 @@ import VegaHeatmap from './VegaHeatmap';
 import PlatformError from '../../../../../../components/PlatformError';
 import { updateCellInfo } from '../../../../../../redux/actions/cellInfo';
 import { loadGeneExpression } from '../../../../../../redux/actions/genes';
+import { loadCellSets } from '../../../../../../redux/actions/cellSets';
 import { loadComponentConfig } from '../../../../../../redux/actions/componentConfig';
 
 import { union } from '../../../../../../utils/cellSetOperations';
@@ -49,6 +50,13 @@ const HeatmapPlot = (props) => {
     setVegaData(data);
   }, 1500, { leading: true }), []);
 
+  /**
+   * Loads cell set on initial render if it does not already exist in the store.
+   */
+  useEffect(() => {
+    dispatch(loadCellSets(experimentId));
+  }, []);
+
   useEffect(() => {
     if (!_.isEmpty(heatmapSettings)) {
       return;
@@ -58,6 +66,10 @@ const HeatmapPlot = (props) => {
   }, [heatmapSettings]);
 
   useEffect(() => {
+    if (hierarchy.length === 0) {
+      return;
+    }
+
     if (!selectedGenes || selectedGenes.length === 0) {
       return;
     }

--- a/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/components/heatmap/HeatmapPlot.jsx
@@ -34,6 +34,7 @@ const HeatmapPlot = (props) => {
   const expressionData = useSelector((state) => state.genes.expression);
   const hoverCoordinates = useRef({});
 
+  const cellSetsLoading = useSelector((state) => state.cellSets.loading);
   const hierarchy = useSelector((state) => state.cellSets.hierarchy);
   const properties = useSelector((state) => state.cellSets.properties);
   const hidden = useSelector((state) => state.cellSets.hidden);
@@ -66,7 +67,7 @@ const HeatmapPlot = (props) => {
   }, [heatmapSettings]);
 
   useEffect(() => {
-    if (hierarchy.length === 0) {
+    if (hierarchy.length === 0 || cellSetsLoading) {
       return;
     }
 


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-413

#### Link to staging deployment URL
https://ui-d99wote1jtjiao3h9fm9uscg4y.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
Added a `loadCellSets` hook to the component so it is responsible for its own loading of cell sets.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [x] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [x] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
