### PR TITLE
Avoid creating empty cell sets.

### DIFF
--- a/src/components/notification/messages.js
+++ b/src/components/notification/messages.js
@@ -1,5 +1,6 @@
 export default {
-  newClusterCreated: 'Created a new cluster. Check `Cell set` window',
+  newClusterCreated: 'Created a new cluster. Check the `Data Management` window.',
+  emptyClusterNotCreated: 'Cannot create a cluster that would be empty.',
   saveCellSets: 'Could not connect to the server. Check your internet connection.',
   plotLoadError: 'Could not load your plot. Check your internet connection or reload the page and try again.',
   feedbackSuccessful: 'Your feedback has been successfully sent. Thank you!',

--- a/src/redux/actions/cellSets/createCellSet.js
+++ b/src/redux/actions/cellSets/createCellSet.js
@@ -20,6 +20,11 @@ const createCellSet = (experimentId, name, color, cellIds) => (dispatch, getStat
     cellIds: new Set([...cellIds].map((id) => parseInt(id, 10))),
   };
 
+  if (data.cellIds.size === 0) {
+    dispatch(pushNotificationMessage('info', messages.emptyClusterNotCreated, 5));
+    return;
+  }
+
   dispatch({
     type: CELL_SETS_CREATE,
     payload: {


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-474

#### Link to staging deployment URL 

https://ui-biomage-474.scp-staging.biomage.net

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

Simple check to avoid saving the new cell set if it contains zero items. A message is shown to the user.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [x] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
