### PR TITLE
resolution and minDistance fires event only after change

### DIFF
--- a/src/__test__/pages/experiments/[experimentId]/data-processing/configure-embedding/components/CalculationConfig.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-processing/configure-embedding/components/CalculationConfig.test.jsx
@@ -22,7 +22,7 @@ jest.mock('localforage');
 enableFetchMocks();
 const mockStore = configureStore([thunk]);
 
-describe('CalculationConfig', () => {
+describe('Data Processing CalculationConfig', () => {
   const storeState = {
     embeddings: initialEmbeddingState,
     experimentSettings: {
@@ -174,9 +174,7 @@ describe('CalculationConfig', () => {
     button.simulate('click', {});
 
     // Should load the new embedding and save the config.
-    await waitForActions(store,
-      [EMBEDDINGS_LOADING, EXPERIMENT_SETTINGS_PROCESSING_SAVE,
-      ]);
+    await waitForActions(store, [EXPERIMENT_SETTINGS_PROCESSING_UPDATE, EMBEDDINGS_LOADING]);
 
     expect(store.getActions().length).toEqual(2);
     expect(store.getActions()).toMatchSnapshot();

--- a/src/__test__/pages/experiments/[experimentId]/data-processing/configure-embedding/components/__snapshots__/CalculationConfig.test.jsx.snap
+++ b/src/__test__/pages/experiments/[experimentId]/data-processing/configure-embedding/components/__snapshots__/CalculationConfig.test.jsx.snap
@@ -1,20 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CalculationConfig clicking on button triggers save action and reloading of plot data 1`] = `
+exports[`Data Processing CalculationConfig clicking on button triggers save action and reloading of plot data 1`] = `
 Array [
+  Object {
+    "payload": Object {
+      "configChange": Object {
+        "embeddingSettings": Object {
+          "method": "tsne",
+        },
+      },
+      "experimentId": "1234",
+      "settingName": "configureEmbedding",
+    },
+    "type": "experimentSettings/updateProcessing",
+  },
   Object {
     "payload": Object {
       "embeddingType": "umap",
       "experimentId": "1234",
     },
     "type": "embeddings/loading",
-  },
-  Object {
-    "payload": Object {
-      "experimentId": "1234",
-      "settingName": "configureEmbedding",
-    },
-    "type": "experimentSettings/saveProcessing",
   },
 ]
 `;

--- a/src/pages/experiments/[experimentId]/data-processing/configure-embedding/components/CalculationConfig.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/configure-embedding/components/CalculationConfig.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import _ from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  Collapse, InputNumber, Form, Select, Typography, Tooltip, Slider, Button, Alert, Spin,
+  Collapse, InputNumber, Form, Select, Typography, Tooltip, Slider, Button, Alert,
 } from 'antd';
 import PropTypes from 'prop-types';
 import { QuestionCircleOutlined } from '@ant-design/icons';
@@ -52,9 +52,9 @@ const CalculationConfig = (props) => {
     }
   }, [umapSettings]);
 
-  const dispatchDebounce = _.debounce((f) => {
+  const dispatchDebounce = useCallback(_.debounce((f) => {
     dispatch(f);
-  }, 1500);
+  }, 1500), []);
 
   const updateSettings = (diff) => {
     if (diff.embeddingSettings) {
@@ -111,15 +111,7 @@ const CalculationConfig = (props) => {
                 { methodSettings: { umap: { minimumDistance: parseFloat(value) } } },
             },
           )}
-          onPressEnter={(e) => {
-            e.preventDefault();
-            updateSettings(
-              {
-                embeddingSettings:
-                  { methodSettings: { umap: { minimumDistance: parseFloat(e.target.value) } } },
-              },
-            );
-          }}
+          onPressEnter={(e) => e.preventDefault()}
           onBlur={(e) => {
             updateSettings(
               {


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-542
https://biomage.atlassian.net/browse/BIOMAGE-545

#### Link to staging deployment URL 

https://ui-kocjfd3mq4p54bjrfz1iggw66h.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- `resolution` only fires action when finished changing the value
-  `minDistance` changes value only after step (clicking the arrow) or `onBlur` when the user leaves focus of the input
- Prevented config to run when user presses enter when inputting `minDistance`

# Changes
### Code changes

- Created local states to handle 'during change' transitions
- Moved dispatch out of `setChangesOutstanding` so that it fires

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
