### PR TITLE
Fix plots and tables bug on SelectCellSets

### DIFF
--- a/src/components/plot-styling/frequency/SelectCellSets.jsx
+++ b/src/components/plot-styling/frequency/SelectCellSets.jsx
@@ -13,13 +13,13 @@ const SelectCellSets = (props) => {
   const firstLetterUppercase = (word) => word.charAt(0).toUpperCase() + word.slice(1);
   const changeClusters = (val) => {
     const newValue = val.key.toLowerCase();
-    onUpdate({ chosenClusters: newValue });
+    onUpdate({ proportionGrouping: newValue });
   };
   let disabled = false;
   let toolTipText;
   const changeMetadata = (val) => {
     const newValue = val.key.toLowerCase();
-    onUpdate({ metadata: newValue });
+    onUpdate({ xAxisGrouping: newValue });
   };
 
   const getSelectOptions = (options) => {
@@ -42,7 +42,7 @@ const SelectCellSets = (props) => {
     disabled = true;
     toolTipText = 'The x-axis cannot be changed as this dataset has only a single sample.';
   } else {
-    menuValue = firstLetterUppercase(config.metadata);
+    menuValue = firstLetterUppercase(config.xAxisGrouping);
   }
   return (
     <>
@@ -72,7 +72,7 @@ const SelectCellSets = (props) => {
       <Form.Item>
         <Select
           value={{
-            key: firstLetterUppercase(config.chosenClusters),
+            key: firstLetterUppercase(config.proportionGrouping),
           }}
           onChange={changeClusters}
           labelInValue


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/ui/pull/108

#### Anything else the reviewers should know about the changes here
A bug was introduced by the related PR when fixing merge conflicts, selectCellSets had stopped working properly.

# Changes
### Code changes
Rename config.metadata and .chosenClusters to their updated names so that the component can be used in the updated frequency plot.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
