### PR TITLE
Create generic listen socket

### DIFF
--- a/src/components/ContentWrapper.jsx
+++ b/src/components/ContentWrapper.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
@@ -15,6 +15,7 @@ import {
   FolderOpenOutlined,
 } from '@ant-design/icons';
 import NotificationManager from './notification/NotificationManager';
+import initUpdateSocket from '../utils/initUpdatesSocket';
 
 const { Sider, Footer } = Layout;
 const { Paragraph } = Typography;
@@ -25,6 +26,14 @@ const ContentWrapper = (props) => {
   const router = useRouter();
   const { experimentId } = router.query;
   const route = router.route || '';
+
+  const updateSocket = useRef(null);
+
+  useEffect(() => {
+    if (experimentId) {
+      updateSocket.current = initUpdateSocket(experimentId, (res) => { console.log(res); });
+    }
+  }, [experimentId]);
 
   const BigLogo = () => (
     <div

--- a/src/components/ContentWrapper.jsx
+++ b/src/components/ContentWrapper.jsx
@@ -15,7 +15,7 @@ import {
   FolderOpenOutlined,
 } from '@ant-design/icons';
 import NotificationManager from './notification/NotificationManager';
-import initUpdateSocket from '../utils/initUpdatesSocket';
+import initUpdateSocket from '../utils/initUpdateSocket';
 
 const { Sider, Footer } = Layout;
 const { Paragraph } = Typography;

--- a/src/utils/initUpdateSocket.js
+++ b/src/utils/initUpdateSocket.js
@@ -1,10 +1,10 @@
 import socketIOClient from 'socket.io-client';
 import getApiEndpoint from './apiEndpoint';
 
-const initUpdatesSocket = async (experimentId, cb) => {
+const initUpdateSocket = async (experimentId, cb) => {
   const io = socketIOClient(getApiEndpoint());
   io.on(`ExperimentUpdates-${experimentId}`, cb);
   return io;
 };
 
-export default initUpdatesSocket;
+export default initUpdateSocket;

--- a/src/utils/initUpdatesSocket.js
+++ b/src/utils/initUpdatesSocket.js
@@ -1,0 +1,10 @@
+import socketIOClient from 'socket.io-client';
+import getApiEndpoint from './apiEndpoint';
+
+const initUpdatesSocket = async (experimentId, cb) => {
+  const io = socketIOClient(getApiEndpoint());
+  io.on(`ExperimentUpdates-${experimentId}`, cb);
+  return io;
+};
+
+export default initUpdatesSocket;


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-516

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

N.A.

# Changes
### Code changes

- Added `initUpdateSocket` - a function to initialize the update socket
- Store the created socket under a `useRef` so that it persists over re-renders.
- Tested locally with a local server

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
