### PR TITLE
Combine/intersect popover disappears after users stops hovering over, even if they are typing

### DIFF
--- a/src/components/data-exploration/cell-sets-tool/CellSetOperation.jsx
+++ b/src/components/data-exploration/cell-sets-tool/CellSetOperation.jsx
@@ -25,10 +25,11 @@ const CellSetOperation = (props) => {
       }}
       onCancel={() => {
         onCancel();
+        setPopoverKey(Math.random());
       }}
       key={popoverKey}
       message={helpTitle}
-      trigger='hover'
+      trigger='click'
     >
       <Button type='dashed' icon={icon} size='small' />
     </ClusterPopover>

--- a/src/components/data-exploration/cell-sets-tool/CellSetOperation.jsx
+++ b/src/components/data-exploration/cell-sets-tool/CellSetOperation.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  Button,
+  Button, Tooltip,
 } from 'antd';
 
 import ClusterPopover from '../embedding/ClusterPopover';
@@ -30,8 +30,11 @@ const CellSetOperation = (props) => {
       key={popoverKey}
       message={helpTitle}
       trigger='click'
+
     >
-      <Button type='dashed' icon={icon} size='small' />
+      <Tooltip title={helpTitle} trigger='click hover'>
+        <Button type='dashed' icon={icon} size='small' />
+      </Tooltip>
     </ClusterPopover>
   );
 };


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-581

#### Link to staging deployment URL 
https://ui-martinfosco-ui154.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
