### PR TITLE
Return user to Compute embedding view when change louvain resolution

### DIFF
--- a/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
@@ -55,7 +55,6 @@ const ConfigureEmbedding = (props) => {
       plotType: 'embeddingPreviewBySample',
       plot: (config, plotData) => (<CategoricalEmbeddingPlot experimentId={experimentId} config={config} plotData={plotData} />),
     },
-
     cellCluster: {
       title: 'Colored by CellSets',
       imgSrc: plot1Pic,

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -205,21 +205,19 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   }, [loading]);
 
   useEffect(() => {
-    const goToStepIdx = () => {
-      if (carouselRef.current) {
-        carouselRef.current.goTo(stepIdx, true);
-      }
-    };
-
     const completeProcessingStepIfAdvanced = () => {
       if (stepIdx > completedSteps.size) {
         dispatch(completeProcessingStep(experimentId, steps[stepIdx - 1].key, steps.length));
       }
     };
 
-    goToStepIdx();
-    completeProcessingStepIfAdvanced();
-  }, [stepIdx]);
+    if (carouselRef.current) {
+      carouselRef.current.goTo(stepIdx, true);
+      completeProcessingStepIfAdvanced();
+    }
+  }, [stepIdx, carouselRef.current]);
+
+
 
   useEffect(() => {
     if (completingStepError && stepIdx > completedSteps.size) {
@@ -307,7 +305,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
             <StepsIndicator
               allSteps={steps}
               currentStep={stepIdx}
-              completedSteps = {completedSteps.size}
+              completedSteps={completedSteps.size}
             />
             <Text type='primary'>{`${completedSteps.size} of ${steps.length} steps complete`}</Text>
             <Button


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-637

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
