### PR TITLE
Add link to FDR tooltip

### DIFF
--- a/src/components/data-processing/Classifier/CalculationConfig.jsx
+++ b/src/components/data-processing/Classifier/CalculationConfig.jsx
@@ -98,7 +98,26 @@ const CalculationConfig = (props) => {
       </Radio.Group>
       <Form.Item label='FDR:'>
         <Space direction='horizontal'>
-          <Tooltip title='False discovery rate (FDR) is calculated for each barcode by using the ‘emptyDrops’ function (https://rdrr.io/github/MarioniLab/DropletUtils/man/emptyDrops.html). This distinguishes between droplets containing cells and ambient RNA. The FDR range is [0-1]. The default FDR value is 0.01, where only barcodes with FDR < 0.01 are retained.'>
+          <Tooltip overlay={(
+            <span>
+              False discovery rate (FDR) is calculated for each barcode by using the
+              {' '}
+              <a
+                href='https://rdrr.io/github/MarioniLab/DropletUtils/man/emptyDrops.html'
+                target='_blank'
+                rel='noreferrer'
+              >
+                <code>emptyDrops</code>
+                {' '}
+                function
+              </a>
+              . This
+              distinguishes between droplets containing cells and ambient RNA. The FDR range is
+              [0-1]. The default FDR value is 0.01, where only barcodes with FDR &lt; 0.01
+              are retained.
+            </span>
+          )}
+          >
             <InfoCircleOutlined />
           </Tooltip>
           <InputNumber


### PR DESCRIPTION
# Background
#### Link to issue 

N/A. @vickymorrison asked in slack if it was possible to add a working link to a tooltip.

#### Link to staging deployment URL 

N/A

#### Links to any Pull Requests related to this

N/A

#### Anything else the reviewers should know about the changes here

_`emptyDrops` function_ is now a clickable link that opens in a new tab/windows

<img width="530" alt="Screenshot 2021-03-26 at 07 24 31" src="https://user-images.githubusercontent.com/460418/112591224-56ab1c80-8e04-11eb-9bf8-bbe813360ab9.png">

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] ~~Relevant Github READMEs updated~~
- [ ] ~~Relevant wiki pages created/updated~~

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by @vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] ~~After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging~~

### Optional
- [x] Photo of a cute animal attached to this PR
![spider](https://user-images.githubusercontent.com/460418/112592090-adfdbc80-8e05-11eb-9c91-fddbacbcd0c1.jpeg)
