### PR TITLE
gene not found error added

### DIFF
--- a/src/__test__/redux/actions/genes/__snapshots__/loadGeneExpression.test.js.snap
+++ b/src/__test__/redux/actions/genes/__snapshots__/loadGeneExpression.test.js.snap
@@ -64,7 +64,7 @@ Object {
     },
     "experimentId": "1234",
     "genes": Array [
-      "a",
+      "geneA",
       "b",
       "c",
     ],

--- a/src/__test__/redux/actions/genes/__snapshots__/loadGeneExpression.test.js.snap
+++ b/src/__test__/redux/actions/genes/__snapshots__/loadGeneExpression.test.js.snap
@@ -65,8 +65,6 @@ Object {
     "experimentId": "1234",
     "genes": Array [
       "geneA",
-      "b",
-      "c",
     ],
   },
   "type": "genes/expressionLoaded",

--- a/src/__test__/redux/reducers/__snapshots__/genesReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/genesReducer.test.js.snap
@@ -107,7 +107,11 @@ Object {
     ],
     "views": Object {
       "asd": Object {
-        "data": Array [],
+        "data": Array [
+          "a",
+          "b",
+          "c",
+        ],
         "error": false,
         "fetching": false,
       },
@@ -243,19 +247,12 @@ Object {
     ],
     "views": Object {
       "abc": Object {
-        "data": Array [
-          "a",
-          "b",
-        ],
+        "data": Array [],
         "error": false,
         "fetching": true,
       },
       "def": Object {
-        "data": Array [
-          "a",
-          "b",
-          "c",
-        ],
+        "data": Array [],
         "error": false,
         "fetching": true,
       },
@@ -418,7 +415,7 @@ Object {
     "loading": Array [],
     "views": Object {
       "abc": Object {
-        "data": Array [],
+        "data": undefined,
         "error": false,
         "fetching": false,
       },
@@ -446,11 +443,7 @@ Object {
     ],
     "views": Object {
       "abc": Object {
-        "data": Array [
-          "A",
-          "B",
-          "C",
-        ],
+        "data": Array [],
         "error": false,
         "fetching": true,
       },

--- a/src/__test__/redux/reducers/__snapshots__/genesReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/genesReducer.test.js.snap
@@ -102,8 +102,8 @@ Object {
     },
     "error": false,
     "loading": Array [
-      "d",
-      "e",
+      "D",
+      "E",
     ],
     "views": Object {
       "asd": Object {

--- a/src/__test__/redux/reducers/genesReducer.test.js
+++ b/src/__test__/redux/reducers/genesReducer.test.js
@@ -95,7 +95,7 @@ describe('genesReducer', () => {
       },
     });
 
-    expect(newState.expression.loading).toEqual(['d', 'e']);
+    expect(newState.expression.loading).toEqual(['D', 'E']);
     expect(newState).toMatchSnapshot();
   });
 

--- a/src/pages/experiments/[experimentId]/plots-and-tables/heatmap/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/heatmap/index.jsx
@@ -104,10 +104,10 @@ const HeatmapPlot = ({ experimentId }) => {
     dispatch(updatePlotConfig(plotUuid, updatedField));
   };
 
-  const onGeneEnter = (value) => {
+  const onGeneEnter = (genes) => {
     // updating the selected genes in the config too so they are saved in dynamodb
 
-    dispatch(loadGeneExpression(experimentId, value, plotUuid));
+    dispatch(loadGeneExpression(experimentId, genes, plotUuid));
   };
   const renderPlot = () => {
     if (!config || loading.length > 0 || cellSets.loading) {

--- a/src/pages/experiments/[experimentId]/plots-and-tables/heatmap/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/heatmap/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import {
-  Row, Col, Space, Collapse, Skeleton, Empty, Typography, message,
+  Row, Col, Space, Collapse, Skeleton, Empty, Typography,
 } from 'antd';
 import _ from 'lodash';
 import { useSelector, useDispatch } from 'react-redux';

--- a/src/redux/actions/genes/loadGeneExpression.js
+++ b/src/redux/actions/genes/loadGeneExpression.js
@@ -1,7 +1,8 @@
+import _ from 'lodash';
 import {
   GENES_EXPRESSION_LOADING, GENES_EXPRESSION_ERROR, GENES_EXPRESSION_LOADED,
 } from '../../actionTypes/genes';
-
+import pushNotificationMessage from '../pushNotificationMessage';
 import { fetchCachedWork } from '../../../utils/cacheRequest';
 
 const loadGeneExpression = (
@@ -56,16 +57,30 @@ const loadGeneExpression = (
     if (Object.keys(data).length === 0) {
       throw Error('There is no information available for selected genes.');
     }
-
-    dispatch({
-      type: GENES_EXPRESSION_LOADED,
-      payload: {
-        experimentId,
-        componentUuid,
-        genes,
-        data,
-      },
-    });
+    const loadedGenes = _.cloneDeep(genes);
+    if (data[genesToFetch[0]].message) {
+      dispatch(pushNotificationMessage('error', `Gene ${genesToFetch[0]} is not found!`, 3));
+      const index = genes.indexOf(genesToFetch[0]);
+      loadedGenes.splice(index, 1);
+      dispatch({
+        type: GENES_EXPRESSION_LOADED,
+        payload: {
+          data: [],
+          genes: loadedGenes,
+          stopLoading: true,
+        },
+      });
+    } else {
+      dispatch({
+        type: GENES_EXPRESSION_LOADED,
+        payload: {
+          experimentId,
+          componentUuid,
+          genes,
+          data,
+        },
+      });
+    }
   } catch (error) {
     dispatch({
       type: GENES_EXPRESSION_ERROR,

--- a/src/redux/actions/genes/loadGeneExpression.js
+++ b/src/redux/actions/genes/loadGeneExpression.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
   GENES_EXPRESSION_LOADING, GENES_EXPRESSION_ERROR, GENES_EXPRESSION_LOADED,
 } from '../../actionTypes/genes';
@@ -67,12 +68,20 @@ const loadGeneExpression = (
         },
       });
     } else {
+      let fetchedGenes = _.cloneDeep(genes);
+      const index = genes.indexOf(genesToFetch[0]);
+      // eslint-disable-next-line prefer-destructuring
+      fetchedGenes[index] = Object.keys(data)[0];
+
+      // making sure there are no repeating genes in the selectedGenes
+      fetchedGenes = Array.from(new Set(fetchedGenes));
+
       dispatch({
         type: GENES_EXPRESSION_LOADED,
         payload: {
           experimentId,
           componentUuid,
-          genes,
+          genes: fetchedGenes,
           data,
         },
       });

--- a/src/redux/actions/genes/loadGeneExpression.js
+++ b/src/redux/actions/genes/loadGeneExpression.js
@@ -56,8 +56,8 @@ const loadGeneExpression = (
     if (Object.keys(data).length === 0) {
       throw Error('There is no information available for selected genes.');
     }
-    if (data[genesToFetch[0]]?.message) {
-      dispatch(pushNotificationMessage('error', `Gene ${genesToFetch[0]} is not found!`, 3));
+    if (data[genesToFetch[0]]?.error) {
+      dispatch(pushNotificationMessage('error', data[genesToFetch[0]].message, 3));
       dispatch({
         type: GENES_EXPRESSION_LOADED,
         payload: {

--- a/src/redux/actions/genes/loadGeneExpression.js
+++ b/src/redux/actions/genes/loadGeneExpression.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import {
   GENES_EXPRESSION_LOADING, GENES_EXPRESSION_ERROR, GENES_EXPRESSION_LOADED,
 } from '../../actionTypes/genes';
@@ -30,9 +29,9 @@ const loadGeneExpression = (
   // Check which of the genes we actually need to load. Only do this if
   // we are not forced to reload all of the data.
   let genesToFetch = [...genes];
+  const genesAlreadyLoaded = new Set(Object.keys(geneData));
 
   if (!forceReloadAll) {
-    const genesAlreadyLoaded = new Set(Object.keys(geneData));
     genesToFetch = genesToFetch.filter((gene) => !genesAlreadyLoaded.has(gene));
   }
 
@@ -57,16 +56,13 @@ const loadGeneExpression = (
     if (Object.keys(data).length === 0) {
       throw Error('There is no information available for selected genes.');
     }
-    const loadedGenes = _.cloneDeep(genes);
-    if (data[genesToFetch[0]].message) {
+    if (data[genesToFetch[0]]?.message) {
       dispatch(pushNotificationMessage('error', `Gene ${genesToFetch[0]} is not found!`, 3));
-      const index = genes.indexOf(genesToFetch[0]);
-      loadedGenes.splice(index, 1);
       dispatch({
         type: GENES_EXPRESSION_LOADED,
         payload: {
           data: [],
-          genes: loadedGenes,
+          genes: genesAlreadyLoaded,
           stopLoading: true,
         },
       });

--- a/src/redux/actions/genes/loadGeneExpression.js
+++ b/src/redux/actions/genes/loadGeneExpression.js
@@ -63,7 +63,7 @@ const loadGeneExpression = (
         payload: {
           data: [],
           genes: genesAlreadyLoaded,
-          stopLoading: true,
+          loadingStatus: [],
         },
       });
     } else {

--- a/src/redux/reducers/genes/genesExpressionLoaded.js
+++ b/src/redux/reducers/genes/genesExpressionLoaded.js
@@ -2,7 +2,9 @@ import _ from 'lodash';
 import { initialViewState } from './initialState';
 
 const genesExpressionLoaded = (state, action) => {
-  const { data, componentUuid, genes } = action.payload;
+  const {
+    data, componentUuid, genes, stopLoading = false,
+  } = action.payload;
   return {
     ...state,
     expression: {
@@ -14,13 +16,14 @@ const genesExpressionLoaded = (state, action) => {
           ...state.expression.views[componentUuid],
           fetching: false,
           error: false,
+          data: genes,
         },
       },
       data: {
         ...state.expression.data,
         ...data,
       },
-      loading: _.difference(state.expression.loading, genes),
+      loading: stopLoading || _.difference(state.expression.loading, genes),
     },
   };
 };

--- a/src/redux/reducers/genes/genesExpressionLoaded.js
+++ b/src/redux/reducers/genes/genesExpressionLoaded.js
@@ -2,13 +2,8 @@ import _ from 'lodash';
 import { initialViewState } from './initialState';
 
 const genesExpressionLoaded = (state, action) => {
-  const upperCaseArray = (array) => {
-    let newArray = [];
-    if (array) {
-      newArray = array.map((element) => element.toLowerCase());
-    }
-    return newArray;
-  };
+  const upperCaseArray = (array) => (array?.map((element) => element.toUpperCase()));
+
   const {
     data, componentUuid, genes,
     loadingStatus = _.difference(upperCaseArray(state.expression.loading), upperCaseArray(genes)),

--- a/src/redux/reducers/genes/genesExpressionLoaded.js
+++ b/src/redux/reducers/genes/genesExpressionLoaded.js
@@ -2,7 +2,12 @@ import _ from 'lodash';
 import { initialViewState } from './initialState';
 
 const genesExpressionLoaded = (state, action) => {
-  const lowerCaseArray = (array) => (array.map((element) => element.toLowerCase()));
+  const lowerCaseArray = (array) => {
+    if (array) {
+      array.map((element) => element.toLowerCase());
+    }
+    return array;
+  };
   const {
     data, componentUuid, genes,
     loadingStatus = _.difference(lowerCaseArray(state.expression.loading), lowerCaseArray(genes)),

--- a/src/redux/reducers/genes/genesExpressionLoaded.js
+++ b/src/redux/reducers/genes/genesExpressionLoaded.js
@@ -2,8 +2,10 @@ import _ from 'lodash';
 import { initialViewState } from './initialState';
 
 const genesExpressionLoaded = (state, action) => {
+  const lowerCaseArray = (array) => (array.map((element) => element.toLowerCase()));
   const {
-    data, componentUuid, genes, loadingStatus = _.difference(state.expression.loading, genes),
+    data, componentUuid, genes,
+    loadingStatus = _.difference(lowerCaseArray(state.expression.loading), lowerCaseArray(genes)),
   } = action.payload;
   return {
     ...state,

--- a/src/redux/reducers/genes/genesExpressionLoaded.js
+++ b/src/redux/reducers/genes/genesExpressionLoaded.js
@@ -3,7 +3,7 @@ import { initialViewState } from './initialState';
 
 const genesExpressionLoaded = (state, action) => {
   const {
-    data, componentUuid, genes, stopLoading = false,
+    data, componentUuid, genes, loadingStatus = _.difference(state.expression.loading, genes),
   } = action.payload;
   return {
     ...state,
@@ -23,7 +23,7 @@ const genesExpressionLoaded = (state, action) => {
         ...state.expression.data,
         ...data,
       },
-      loading: stopLoading || _.difference(state.expression.loading, genes),
+      loading: loadingStatus,
     },
   };
 };

--- a/src/redux/reducers/genes/genesExpressionLoaded.js
+++ b/src/redux/reducers/genes/genesExpressionLoaded.js
@@ -2,16 +2,18 @@ import _ from 'lodash';
 import { initialViewState } from './initialState';
 
 const genesExpressionLoaded = (state, action) => {
-  const lowerCaseArray = (array) => {
+  const upperCaseArray = (array) => {
+    let newArray = [];
     if (array) {
-      array.map((element) => element.toLowerCase());
+      newArray = array.map((element) => element.toLowerCase());
     }
-    return array;
+    return newArray;
   };
   const {
     data, componentUuid, genes,
-    loadingStatus = _.difference(lowerCaseArray(state.expression.loading), lowerCaseArray(genes)),
+    loadingStatus = _.difference(upperCaseArray(state.expression.loading), upperCaseArray(genes)),
   } = action.payload;
+
   return {
     ...state,
     expression: {

--- a/src/redux/reducers/genes/genesExpressionLoading.js
+++ b/src/redux/reducers/genes/genesExpressionLoading.js
@@ -15,7 +15,6 @@ const genesExpressionLoading = (state, action) => {
           ...state.expression.views[componentUuid],
           fetching: true,
           error: false,
-          data: genes,
         },
       },
       loading: _.union(state.expression.loading, genes),

--- a/src/utils/cacheRequest.js
+++ b/src/utils/cacheRequest.js
@@ -45,16 +45,15 @@ const fetchCachedGeneExpressionWork = async (experimentId, timeout, body) => {
     return cachedData;
   }
   const response = await sendWork(experimentId, timeout, { ...body, genes: missingGenes });
-
   const responseData = JSON.parse(response.results[0].body);
+  if (!responseData[missingGenes[0]]?.message) {
+    // Preprocessing data before entering cache
+    const processedData = calculateZScore(responseData);
 
-  // Preprocessing data before entering cache
-  const processedData = calculateZScore(responseData);
-
-  Object.keys(missingDataKeys).forEach(async (gene) => {
-    await cache.set(missingDataKeys[gene], processedData[gene]);
-  });
-
+    Object.keys(missingDataKeys).forEach(async (gene) => {
+      await cache.set(missingDataKeys[gene], processedData[gene]);
+    });
+  }
   return responseData;
 };
 

--- a/src/utils/cacheRequest.js
+++ b/src/utils/cacheRequest.js
@@ -46,7 +46,7 @@ const fetchCachedGeneExpressionWork = async (experimentId, timeout, body) => {
   }
   const response = await sendWork(experimentId, timeout, { ...body, genes: missingGenes });
   const responseData = JSON.parse(response.results[0].body);
-  if (!responseData[missingGenes[0]]?.message) {
+  if (!responseData[missingGenes[0]]?.error) {
     // Preprocessing data before entering cache
     const processedData = calculateZScore(responseData);
 

--- a/src/utils/plotSpecs/generateHeatmapSpec.js
+++ b/src/utils/plotSpecs/generateHeatmapSpec.js
@@ -193,11 +193,6 @@ const generateSpec = (config, groupName) => {
 
     axes: [
       {
-        domain: false,
-        orient: 'left',
-        scale: 'y',
-      },
-      {
         orient: 'left',
         scale: 'yTrack',
         domain: false,

--- a/src/utils/sendWork.js
+++ b/src/utils/sendWork.js
@@ -28,11 +28,9 @@ const sendWork = async (experimentId, timeout, body, requestProps = {}) => {
   };
 
   io.emit('WorkRequest', request);
-
   const responsePromise = new Promise((resolve, reject) => {
     io.on(`WorkResponse-${requestUuid}`, (res) => {
       const { response: { error } } = res;
-
       if (error) {
         return reject(new WorkResponseError(error, request));
       }


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-652
#### Link to staging deployment URL 
https://ui-geneerror-ui176-worker92.scp-staging.biomage.net/
#### Links to any Pull Requests related to this
Worker/92 - https://github.com/biomage-ltd/worker/pull/92
#### Anything else the reviewers should know about the changes here

# Changes
When the user types in a gene and it is not found,  a notification message is shown on top of the screen.

Instead of putting an actual error field in the response, a message is sent so that the plot does not fail - the plot stays the same and ignores the unfound gene.

### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
