### PR TITLE
scratchpad deletion bug

### DIFF
--- a/src/__test__/components/data-exploration/cell-sets-tool/CellSetsTool.test.jsx
+++ b/src/__test__/components/data-exploration/cell-sets-tool/CellSetsTool.test.jsx
@@ -316,4 +316,22 @@ describe('CellSetsTool', () => {
     tabs.props().onChange('cellSets');
     expect(text.text()).toEqual('3 cells selected');
   });
+  it('Scratchpad cluster deletion works ', () => {
+    const store = mockStore(storeState);
+    const component = mount(
+      <Provider store={store}>
+        <CellSetsTool
+          experimentId='asd'
+          width={50}
+          height={50}
+        />
+      </Provider>,
+    );
+    waitForComponentToPaint(component);
+    const deleteButton = component.find(DeleteOutlined);
+    expect(deleteButton.length).toEqual(1);
+    expect(store.getActions().length).toEqual(0);
+    deleteButton.simulate('click');
+    expect(store.getActions().length).toEqual(2);
+  });
 });

--- a/src/components/EditableField.jsx
+++ b/src/components/EditableField.jsx
@@ -15,7 +15,6 @@ const EditableField = (props) => {
 
   const [editing, setEditing] = useState(defaultEditing);
   const [editedValue, setEditedValue] = useState(value);
-
   useEffect(() => {
     setEditedValue(value);
   }, [value]);

--- a/src/redux/reducers/cellSets/cellSetsDelete.js
+++ b/src/redux/reducers/cellSets/cellSetsDelete.js
@@ -4,7 +4,6 @@ const cellSetsDelete = (state, action) => {
   const { key } = action.payload;
 
   const newState = _.cloneDeep(state);
-
   // Modify hierarchy to remove the cell set.
   newState.hierarchy = newState.hierarchy.filter((rootNode) => {
     // If it's a root we're removing, delete all its children.
@@ -29,7 +28,7 @@ const cellSetsDelete = (state, action) => {
   delete newState.properties[key];
 
   // If the key was in the list of selected keys, make sure we remove it from there.
-  newState.selected = newState.selected.filter((selectedKey) => selectedKey !== key);
+  newState.selected = newState.selected.cellSets?.filter((selectedKey) => selectedKey !== key);
 
   // Delete from hidden if it was selected to be hidden.
   newState.hidden.delete(key);


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-651
#### Link to staging deployment URL 
soon
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
