### PR TITLE
Hotfix: processing configuration changes cause infinite loop in pre-filtered data sets

### DIFF
--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -98,8 +98,8 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
     if (samples.ids.length > 0) {
       setPreFilteredSamples(
-        samples.ids.reduce(
-          (acc, sampleUuid) => samples[sampleUuid].preFiltered ? [...acc, sampleUuid] : acc, []
+        samples.ids.filter(
+          (sampleUuid) => samples[sampleUuid].preFiltered
         )
       )
     }
@@ -119,7 +119,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
       })
     }
 
-  }, [preFilteredSamples, processingConfig])
+  }, [preFilteredSamples, processingConfig.meta])
 
   useEffect(() => {
     if (
@@ -129,7 +129,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
     ) {
       setDisabledByPrefilter(stepsDisabledByPrefilter.includes(steps[stepIdx].key))
     }
-  }, [stepIdx, processingConfig])
+  }, [stepIdx, processingConfig.meta])
 
   const upcomingStepIdxRef = useRef(null);
 


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
TBD

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
See fix that only triggers on `meta` changes to avoid infinite renders.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR
![image](https://user-images.githubusercontent.com/16019444/115607848-63c10b80-a2dd-11eb-9a94-683f505eae5c.png)
