### PR TITLE
Disable multisample options

### DIFF
--- a/src/__test__/redux/reducers/__snapshots__/differentialExpressionReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/differentialExpressionReducer.test.js.snap
@@ -15,7 +15,7 @@ Object {
         "compareWith": null,
       },
     },
-    "type": "between",
+    "type": "within",
   },
   "properties": Object {
     "cellSets": Object {},
@@ -43,7 +43,7 @@ Object {
         "compareWith": null,
       },
     },
-    "type": "between",
+    "type": "within",
   },
   "properties": Object {
     "cellSets": Object {
@@ -111,7 +111,7 @@ Object {
         "compareWith": null,
       },
     },
-    "type": "between",
+    "type": "within",
   },
   "properties": Object {
     "cellSets": Object {},

--- a/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
@@ -31,6 +31,7 @@ const DiffExprCompute = (props) => {
   const hierarchy = useSelector((state) => state.cellSets.hierarchy);
   const [isFormValid, setIsFormValid] = useState(false);
   const [numSamples, setNumSamples] = useState(1);
+  const [onlySample, setOnlySample] = useState('');
   const comparisonGroup = useSelector((state) => state.differentialExpression.comparison.group);
   const selectedComparison = useSelector((state) => state.differentialExpression.comparison.type);
 
@@ -81,10 +82,17 @@ const DiffExprCompute = (props) => {
 
     });
 
-    // Calculate the number of sampelIds
-    setNumSamples(hierarchy?.find(
+    // Calculate the number of sampleIds.
+    // if there is only 1 sample, set sample using sample name
+    const samples = hierarchy?.find(
       (rootNode) => (rootNode.key === 'sample'),
-    )?.children.length);
+    )?.children;
+
+    setNumSamples(samples.length)
+
+    if (samples.length === 1) {
+      setOnlySample(`sample/${samples[0].key}`)
+    }
 
   }, [hierarchy, properties]);
 
@@ -174,7 +182,8 @@ const DiffExprCompute = (props) => {
           style={{ width: 200 }}
           onChange={(cellSet) => onSelectCluster(cellSet, option)}
           value={
-            comparisonGroup[selectedComparison][option] ?? null
+            option === "basis" && numSamples === 1 ? onlySample :
+              comparisonGroup[selectedComparison][option] ?? null
           }
           size='small'
         >

--- a/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
@@ -30,6 +30,7 @@ const DiffExprCompute = (props) => {
   const properties = useSelector((state) => state.cellSets.properties);
   const hierarchy = useSelector((state) => state.cellSets.hierarchy);
   const [isFormValid, setIsFormValid] = useState(false);
+  const [numSamples, setNumSamples] = useState(1);
   const comparisonGroup = useSelector((state) => state.differentialExpression.comparison.group);
   const selectedComparison = useSelector((state) => state.differentialExpression.comparison.type);
 
@@ -79,6 +80,11 @@ const DiffExprCompute = (props) => {
       }
 
     });
+
+    // Calculate the number of sampelIds
+    setNumSamples(hierarchy?.find(
+      (rootNode) => (rootNode.key === 'sample'),
+    )?.children.length);
 
   }, [hierarchy, properties]);
 
@@ -216,7 +222,7 @@ const DiffExprCompute = (props) => {
         <Radio
           style={radioStyle}
           value={ComparisonType.between}
-          disabled={!hasMetadata}
+          disabled={!hasMetadata || numSamples === 1}
         >
           Compare a selected cell set between samples/groups
         </Radio>

--- a/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
@@ -210,15 +210,15 @@ const DiffExprCompute = (props) => {
       }} defaultValue={selectedComparison}>
         <Radio
           style={radioStyle}
+          value={ComparisonType.within}>
+          Compare cell sets within a sample/group
+        </Radio>
+        <Radio
+          style={radioStyle}
           value={ComparisonType.between}
           disabled={!hasMetadata}
         >
           Compare a selected cell set between samples/groups
-        </Radio>
-        <Radio
-          style={radioStyle}
-          value={ComparisonType.within}>
-          Compare cell sets within a sample/group
         </Radio>
       </Radio.Group>
 

--- a/src/components/data-processing/CalculationConfigContainer.jsx
+++ b/src/components/data-processing/CalculationConfigContainer.jsx
@@ -14,7 +14,7 @@ import { updateProcessingSettings } from '../../redux/actions/experimentSettings
 
 const CalculationConfigContainer = (props) => {
   const {
-    filterUuid, experimentId, sampleId, plotType, sampleIds, onConfigChange, children,
+    filterUuid, experimentId, sampleId, plotType, sampleIds, onConfigChange, children, stepDisabled,
   } = props;
 
   const { auto, filterSettings: config } = useSelector(
@@ -79,6 +79,7 @@ const CalculationConfigContainer = (props) => {
         value={auto ? 'automatic' : 'manual'}
         onChange={(e) => { updateAuto(e.target.value === 'automatic'); }}
         style={{ marginTop: '5px', marginBottom: '30px' }}
+        disabled={stepDisabled}
       >
         <Radio value='automatic'>
           Automatic
@@ -89,7 +90,7 @@ const CalculationConfigContainer = (props) => {
       </Radio.Group>
 
       {React.cloneElement(children, {
-        config, plotType, updateSettings, disabled: auto,
+        config, plotType, updateSettings, disabled: stepDisabled || auto,
       })}
 
       {
@@ -109,6 +110,11 @@ CalculationConfigContainer.propTypes = {
   plotType: PropTypes.string.isRequired,
   sampleIds: PropTypes.array.isRequired,
   onConfigChange: PropTypes.func.isRequired,
+  stepDisabled: PropTypes.bool,
+};
+
+CalculationConfigContainer.defaultProps = {
+  stepDisabled: false,
 };
 
 export default CalculationConfigContainer;

--- a/src/components/data-processing/CalculationConfigContainer.jsx
+++ b/src/components/data-processing/CalculationConfigContainer.jsx
@@ -47,10 +47,10 @@ const CalculationConfigContainer = (props) => {
     const newConfig = _.cloneDeep(config);
     _.merge(newConfig, diff);
 
-    updateSample({ [sampleId]: { auto, filterSettings: newConfig } });
+    updateSample({ [sampleId]: { filterSettings: newConfig } });
   };
   const updateAuto = (autoMode) => {
-    updateSample({ [sampleId]: { auto: autoMode, filterSettings: config } });
+    updateSample({ [sampleId]: { auto: autoMode } });
   };
   const updateSample = (newSampleSettings) => {
     setDisplayIndividualChangesWarning(true);
@@ -67,7 +67,7 @@ const CalculationConfigContainer = (props) => {
     <div>
 
       <Space direction='vertical' style={{ width: '100%' }} />
-      {displayIndividualChangesWarning && (
+      {displayIndividualChangesWarning && sampleIds.length > 1 && (
         <Alert
           message='To copy these new settings to the rest of your samples, click Copy to all samples.'
           type='info'

--- a/src/components/data-processing/CalculationConfigContainer.jsx
+++ b/src/components/data-processing/CalculationConfigContainer.jsx
@@ -92,7 +92,12 @@ const CalculationConfigContainer = (props) => {
         config, plotType, updateSettings, disabled: auto,
       })}
 
-      <Button onClick={updateAllSettings}>Copy to all samples</Button>
+      {
+        sampleIds.length > 1 ? (
+          <Button onClick={updateAllSettings} disabled={auto === 'automatic'}>Copy to all samples</Button>
+        ) : <></>
+      }
+
     </div>
   );
 };

--- a/src/components/data-processing/CellSizeDistribution/CellSizeDistribution.jsx
+++ b/src/components/data-processing/CellSizeDistribution/CellSizeDistribution.jsx
@@ -28,7 +28,7 @@ import CalculationConfig from './CalculationConfig';
 const { Panel } = Collapse;
 const CellSizeDistribution = (props) => {
   const {
-    experimentId, sampleId, sampleIds, onConfigChange,
+    experimentId, sampleId, sampleIds, onConfigChange, stepDisabled,
   } = props;
 
   const filterName = 'cellSizeDistribution';
@@ -194,6 +194,7 @@ const CellSizeDistribution = (props) => {
                 sampleIds={sampleIds}
                 onConfigChange={onConfigChange}
                 plotType='bin step'
+                stepDisabled={stepDisabled}
               >
                 <CalculationConfig />
               </CalculationConfigContainer>
@@ -218,6 +219,11 @@ CellSizeDistribution.propTypes = {
   sampleId: PropTypes.string.isRequired,
   sampleIds: PropTypes.array.isRequired,
   onConfigChange: PropTypes.func.isRequired,
+  stepDisabled: PropTypes.bool,
+};
+
+CellSizeDistribution.defaultProps = {
+  stepDisabled: false,
 };
 
 export default CellSizeDistribution;

--- a/src/components/data-processing/Classifier/Classifier.jsx
+++ b/src/components/data-processing/Classifier/Classifier.jsx
@@ -23,7 +23,7 @@ const { Panel } = Collapse;
 
 const Classifier = (props) => {
   const {
-    experimentId, sampleId, sampleIds, onConfigChange,
+    experimentId, sampleId, sampleIds, onConfigChange, stepDisabled,
   } = props;
 
   const filterName = 'classifier';
@@ -124,6 +124,7 @@ const Classifier = (props) => {
                 sampleIds={sampleIds}
                 onConfigChange={onConfigChange}
                 plotType='unused'
+                stepDisabled={stepDisabled}
               >
                 <CalculationConfig />
               </CalculationConfigContainer>
@@ -148,6 +149,11 @@ Classifier.propTypes = {
   sampleId: PropTypes.string.isRequired,
   sampleIds: PropTypes.array.isRequired,
   onConfigChange: PropTypes.func.isRequired,
+  stepDisabled: PropTypes.bool,
+};
+
+Classifier.defaultProps = {
+  stepDisabled: false,
 };
 
 export default Classifier;

--- a/src/components/data-processing/DataIntegration/CalculationConfig.jsx
+++ b/src/components/data-processing/DataIntegration/CalculationConfig.jsx
@@ -34,7 +34,7 @@ const { Panel } = Collapse;
 
 const CalculationConfig = (props) => {
   const {
-    experimentId, onPipelineRun,
+    experimentId, onPipelineRun, disabled,
   } = props;
   const FILTER_UUID = 'dataIntegration';
 
@@ -102,6 +102,7 @@ const CalculationConfig = (props) => {
         config={dataIntegration.methodSettings.seuratv4}
         onUpdate={updateSettings}
         onChange={() => setChangesOutstanding(true)}
+        disabled={disabled}
       />
     ),
   };
@@ -145,6 +146,7 @@ const CalculationConfig = (props) => {
               <Select
                 value={dataIntegration.method}
                 onChange={(val) => updateSettings({ dataIntegration: { method: val } })}
+                disabled={disabled}
               >
                 {
                   methods.map((el) => (
@@ -182,12 +184,13 @@ const CalculationConfig = (props) => {
                 onBlur={(e) => updateSettings(
                   { dimensionalityReduction: { numPCs: parseInt(e.target.value, 0) } },
                 )}
+                disabled={disabled}
               />
             </Form.Item>
             <Form.Item label='% variation explained'>
               <InputNumber
                 value={roundedVariationExplained()}
-                disabled
+                disabled={disabled}
                 readOnly
               />
             </Form.Item>
@@ -197,6 +200,7 @@ const CalculationConfig = (props) => {
                   { dimensionalityReduction: { excludeGeneCategories: val } },
                 )}
                 value={dimensionalityReduction.excludeGeneCategories}
+                disabled={disabled}
               >
                 <Space direction='vertical'>
                   <Checkbox value='ribosomal'>ribosomal</Checkbox>
@@ -209,6 +213,7 @@ const CalculationConfig = (props) => {
               <Select
                 value={dimensionalityReduction.method}
                 onChange={(val) => updateSettings({ dimensionalityReduction: { method: val } })}
+                disabled={disabled}
               >
                 <Option key='rpca' value='rpca'>Reciprocal PCA (RPCA)</Option>
                 <Option key='cca' value='cca'>Cannonical Correlation Analysis (CCA)</Option>
@@ -241,6 +246,11 @@ const CalculationConfig = (props) => {
 CalculationConfig.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+CalculationConfig.defaultProps = {
+  disabled: false,
 };
 
 export default CalculationConfig;

--- a/src/components/data-processing/DataIntegration/DataIntegration.jsx
+++ b/src/components/data-processing/DataIntegration/DataIntegration.jsx
@@ -29,7 +29,7 @@ import generateDataProcessingPlotUuid from '../../../utils/generateDataProcessin
 
 const { Panel } = Collapse;
 const DataIntegration = (props) => {
-  const { experimentId, onPipelineRun } = props;
+  const { experimentId, onPipelineRun, stepDisabled } = props;
   const [selectedPlot, setSelectedPlot] = useState('embedding');
   const [plot, setPlot] = useState(null);
   const cellSets = useSelector((state) => state.cellSets);
@@ -366,6 +366,7 @@ const DataIntegration = (props) => {
             experimentId={experimentId}
             config={calculationConfig}
             onPipelineRun={onPipelineRun}
+            disabled={stepDisabled}
           />
           <Collapse>
             <Panel header='Plot styling' key='styling'>
@@ -386,6 +387,11 @@ const DataIntegration = (props) => {
 DataIntegration.propTypes = {
   onPipelineRun: PropTypes.func.isRequired,
   experimentId: PropTypes.string.isRequired,
+  stepDisabled: PropTypes.bool,
+};
+
+DataIntegration.defaultProps = {
+  stepDisabled: false,
 };
 
 export default DataIntegration;

--- a/src/components/data-processing/DataIntegration/SeuratV4Options.jsx
+++ b/src/components/data-processing/DataIntegration/SeuratV4Options.jsx
@@ -5,7 +5,9 @@ import { Form, InputNumber, Select } from 'antd';
 const { Option } = Select;
 
 const SeuratV4Options = (props) => {
-  const { config, onUpdate, onChange } = props;
+  const {
+    config, onUpdate, onChange, disabled,
+  } = props;
 
   const [numGenes, setNumGenes] = useState(config.numGenes);
 
@@ -39,6 +41,7 @@ const SeuratV4Options = (props) => {
               },
             },
           })}
+          disabled={disabled}
         />
       </Form.Item>
       <Form.Item label='normalization'>
@@ -51,6 +54,7 @@ const SeuratV4Options = (props) => {
               },
             },
           })}
+          disabled={disabled}
         >
           <Option value='logNormalize'>LogNormalize</Option>
           <Option value='scTransform'>SCTransform</Option>

--- a/src/components/data-processing/DoubletScores/DoubletScores.jsx
+++ b/src/components/data-processing/DoubletScores/DoubletScores.jsx
@@ -21,7 +21,7 @@ import generateDataProcessingPlotUuid from '../../../utils/generateDataProcessin
 const { Panel } = Collapse;
 const DoubletScores = (props) => {
   const {
-    experimentId, sampleId, sampleIds, onConfigChange,
+    experimentId, sampleId, sampleIds, onConfigChange, stepDisabled,
   } = props;
 
   const filterName = 'doubletScores';
@@ -128,6 +128,7 @@ const DoubletScores = (props) => {
                 sampleIds={sampleIds}
                 onConfigChange={onConfigChange}
                 plotType='bin step'
+                stepDisabled={stepDisabled}
               >
                 <CalculationConfig />
               </CalculationConfigContainer>
@@ -152,9 +153,11 @@ DoubletScores.propTypes = {
   sampleId: PropTypes.string.isRequired,
   sampleIds: PropTypes.array.isRequired,
   onConfigChange: PropTypes.func.isRequired,
+  stepDisabled: PropTypes.bool,
 };
 
 DoubletScores.defaultProps = {
+  stepDisabled: false,
 };
 
 export default DoubletScores;

--- a/src/components/data-processing/GenesVsUMIs/GenesVsUMIs.jsx
+++ b/src/components/data-processing/GenesVsUMIs/GenesVsUMIs.jsx
@@ -22,7 +22,7 @@ const { Panel } = Collapse;
 
 const GenesVsUMIs = (props) => {
   const {
-    experimentId, sampleId, sampleIds, onConfigChange,
+    experimentId, sampleId, sampleIds, onConfigChange, stepDisabled,
   } = props;
 
   const filterName = 'numGenesVsNumUmis';
@@ -126,6 +126,7 @@ const GenesVsUMIs = (props) => {
                 sampleIds={sampleIds}
                 onConfigChange={onConfigChange}
                 plotType='unused'
+                stepDisabled={stepDisabled}
               >
                 <CalculationConfig />
               </CalculationConfigContainer>
@@ -150,6 +151,11 @@ GenesVsUMIs.propTypes = {
   sampleId: PropTypes.string.isRequired,
   sampleIds: PropTypes.array.isRequired,
   onConfigChange: PropTypes.func.isRequired,
+  stepDisabled: PropTypes.bool,
+};
+
+GenesVsUMIs.defaultProps = {
+  stepDisabled: false,
 };
 
 export default GenesVsUMIs;

--- a/src/components/data-processing/MitochondrialContent/MitochondrialContent.jsx
+++ b/src/components/data-processing/MitochondrialContent/MitochondrialContent.jsx
@@ -24,7 +24,7 @@ import CalculationConfig from './CalculationConfig';
 const { Panel } = Collapse;
 const MitochondrialContent = (props) => {
   const {
-    experimentId, sampleId, sampleIds, onConfigChange,
+    experimentId, sampleId, sampleIds, onConfigChange, stepDisabled,
   } = props;
 
   const dispatch = useDispatch();
@@ -193,6 +193,7 @@ const MitochondrialContent = (props) => {
                 sampleIds={sampleIds}
                 onConfigChange={onConfigChange}
                 plotType='bin step'
+                stepDisabled={stepDisabled}
               >
                 <CalculationConfig />
               </CalculationConfigContainer>
@@ -217,6 +218,11 @@ MitochondrialContent.propTypes = {
   sampleId: PropTypes.string.isRequired,
   sampleIds: PropTypes.array.isRequired,
   onConfigChange: PropTypes.func.isRequired,
+  stepDisabled: PropTypes.bool,
+};
+
+MitochondrialContent.defaultProps = {
+  stepDisabled: false,
 };
 
 export default MitochondrialContent;

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -74,11 +74,26 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   const [changesOutstanding, setChangesOutstanding] = useState(false);
   const [showChangesWillBeLost, setShowChangesWillBeLost] = useState(false);
   const [stepIdx, setStepIdx] = useState(0);
+  const [applicableFilters, setApplicableFilters] = useState([])
   const [preFilteredSamples, setPreFilteredSamples] = useState([])
-  const [disabledByPrefilter, setDisabledByPrefilter] = useState(false)
+  const [stepDisabledByCondition, setStepDisabledByCondition] = useState(false)
   const carouselRef = useRef(null);
 
-  const stepsDisabledByPrefilter = ['classifier']
+  const disableStepsOnCondition = {
+    prefilter: ['classifier'],
+    unisample: ['dataIntegration']
+  }
+
+  const disabledConditionMessage = {
+    prefilter: `This filter is disabled because ${preFilteredSamples.join(', ')} ${preFilteredSamples.length > 1 ? 'are' : 'is'} pre-filtered.`,
+    unisample: "This step is disabled because there is only one sample"
+  }
+
+  const sampleKeys = cellSets.hierarchy?.find(
+    (rootNode) => (rootNode.key === 'sample'),
+  )?.children.map(
+    (child) => child.key,
+  );
 
   useEffect(() => {
     if (cellSets.loading && !cellSets.error) {
@@ -113,7 +128,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
       && !processingConfig.meta.loadingSettingsError
       && processingConfig[steps[stepIdx].key].enabled
     ) {
-      stepsDisabledByPrefilter.forEach((step) => {
+      disableStepsOnCondition.prefilter.forEach((step) => {
         dispatch(updateProcessingSettings(experimentId, step, { enabled: false }))
         dispatch(saveProcessingSettings(experimentId, step))
       })
@@ -122,22 +137,23 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   }, [preFilteredSamples, processingConfig.meta])
 
   useEffect(() => {
-    if (
-      preFilteredSamples.length > 0
-      && !processingConfig.meta.loading
-      && !processingConfig.meta.loadingSettingsError
-    ) {
-      setDisabledByPrefilter(stepsDisabledByPrefilter.includes(steps[stepIdx].key))
+    if (sampleKeys && sampleKeys.length === 1) {
+      disableStepsOnCondition.unisample.forEach((step) => {
+        dispatch(updateProcessingSettings(experimentId, step, { enabled: false }))
+        dispatch(saveProcessingSettings(experimentId, step))
+      })
     }
-  }, [stepIdx, processingConfig.meta])
+  }, [cellSets])
+
+  useEffect(() => {
+    const applicableFilters = Object.entries(disableStepsOnCondition).filter(([key, value]) => value.includes(steps[stepIdx].key))
+
+    // Get the first value because return of Object.entries is [filterName,[steps]]
+    setApplicableFilters(applicableFilters.map(filter => filter[0]))
+    setStepDisabledByCondition(applicableFilters.length > 0)
+  }, [stepIdx])
 
   const upcomingStepIdxRef = useRef(null);
-
-  const sampleKeys = cellSets.hierarchy?.find(
-    (rootNode) => (rootNode.key === 'sample'),
-  )?.children.map(
-    (child) => child.key,
-  );
 
   // Checks if the step is in the 'completed steps' list we get from the pipeline status
   const isStepComplete = (stepName) => {
@@ -431,7 +447,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
             <Col>
               {steps[stepIdx].multiSample && (
                 <Button
-                  disabled={disabledByPrefilter}
+                  disabled={stepDisabledByCondition}
                   onClick={() => {
                     dispatch(updateProcessingSettings(
                       experimentId,
@@ -572,16 +588,24 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
             return (
               <Space direction='vertical'>
-                {processingConfig[steps[stepIdx].key].enabled === false &&
-                  < Alert
-                    message={
-                      disabledByPrefilter ?
-                        `This filter is disabled because ${preFilteredSamples.join(', ')} ${preFilteredSamples.length > 1 ? 'are' : 'is'} pre-filtered.`
-                        : 'This filter is disabled. You can still modify and save changes, but the filter will not be applied to your data.'
-                    }
-                    type="info"
-                    showIcon
-                  />
+                {processingConfig[steps[stepIdx].key].enabled === false ?
+                  (
+                    stepDisabledByCondition ? (
+                      applicableFilters.map(filter =>
+                        < Alert
+                          message={disabledConditionMessage[filter]}
+                          type="info"
+                          showIcon
+                        />
+                      )
+                    ) : (
+                      < Alert
+                        message={'This filter is disabled. You can still modify and save changes, but the filter will not be applied to your data.'}
+                        type="info"
+                        showIcon
+                      />
+                    )
+                  ) : <></>
                 }
                 { renderWithInnerScroll(() => render(key, experimentId))}
               </Space>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -588,7 +588,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
             return (
               <Space direction='vertical'>
-                {processingConfig[steps[stepIdx].key].enabled === false ?
+                {processingConfig[steps[stepIdx].key]?.enabled === false ?
                   (
                     stepDisabledByCondition ? (
                       applicableFilters.map(filter =>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -150,7 +150,10 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
     // Get the first value because return of Object.entries is [filterName,[steps]]
     setApplicableFilters(applicableFilters.map(filter => filter[0]))
-    setStepDisabledByCondition(applicableFilters.length > 0)
+    setStepDisabledByCondition(
+      applicableFilters.length > 0
+      && !processingConfig[steps[stepIdx].key]?.enabled
+    )
   }, [stepIdx])
 
   const upcomingStepIdxRef = useRef(null);
@@ -193,6 +196,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               sampleId={sample.key}
               sampleIds={sampleKeys}
               onConfigChange={onConfigChange}
+              stepDisabled={!processingConfig[key]?.enabled}
             />
           )}
         />
@@ -215,6 +219,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               sampleId={sample.key}
               sampleIds={sampleKeys}
               onConfigChange={onConfigChange}
+              stepDisabled={!processingConfig[key].enabled}
             />
           )}
         />
@@ -237,6 +242,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               sampleId={sample.key}
               sampleIds={sampleKeys}
               onConfigChange={onConfigChange}
+              stepDisabled={!processingConfig[key].enabled}
             />
           )}
         />
@@ -259,6 +265,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               sampleId={sample.key}
               sampleIds={sampleKeys}
               onConfigChange={onConfigChange}
+              stepDisabled={!processingConfig[key].enabled}
             />
           )}
         />
@@ -281,6 +288,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               sampleId={sample.key}
               sampleIds={sampleKeys}
               onConfigChange={onConfigChange}
+              stepDisabled={!processingConfig[key].enabled}
             />
           )}
         />
@@ -290,14 +298,27 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
       key: 'dataIntegration',
       name: 'Data integration',
       multiSample: false,
-      render: (key, expId) => <DataIntegration experimentId={expId} key={key} onPipelineRun={() => onPipelineRun(key)} />,
+      render: (key, expId) => (
+        <DataIntegration
+          experimentId={expId}
+          key={key}
+          onPipelineRun={() => onPipelineRun(key)}
+          stepDisabled={!processingConfig[key].enabled}
+        />
+      ),
     },
     {
       key: 'configureEmbedding',
       name: 'Configure embedding',
       description: 'The number of dimensions used to configure the embedding is set here. This dictates the number of clusters in the Uniform Manifold Approximation and Projection (UMAP) which is taken forward to the ‘Data Exploration’ page.',
       multiSample: false,
-      render: (key, expId) => <ConfigureEmbedding experimentId={expId} key={key} onPipelineRun={() => onPipelineRun(key)} />,
+      render: (key, expId) => (
+        <ConfigureEmbedding
+          experimentId={expId}
+          key={key}
+          onPipelineRun={() => onPipelineRun(key)}
+        />
+      ),
     },
   ];
 

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -74,11 +74,26 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   const [changesOutstanding, setChangesOutstanding] = useState(false);
   const [showChangesWillBeLost, setShowChangesWillBeLost] = useState(false);
   const [stepIdx, setStepIdx] = useState(0);
+  const [applicableFilters, setApplicableFilters] = useState([])
   const [preFilteredSamples, setPreFilteredSamples] = useState([])
-  const [disabledByPrefilter, setDisabledByPrefilter] = useState(false)
+  const [stepDisabledByCondition, setStepDisabledByCondition] = useState(false)
   const carouselRef = useRef(null);
 
-  const stepsDisabledByPrefilter = ['classifier']
+  const disableStepsOnCondition = {
+    prefilter: ['classifier'],
+    unisample: ['dataIntegration']
+  }
+
+  const disabledConditionMessage = {
+    prefilter: `This filter is disabled because ${preFilteredSamples.join(', ')} ${preFilteredSamples.length > 1 ? 'are' : 'is'} pre-filtered.`,
+    unisample: "This filter is disabled because there is only one sample"
+  }
+
+  const sampleKeys = cellSets.hierarchy?.find(
+    (rootNode) => (rootNode.key === 'sample'),
+  )?.children.map(
+    (child) => child.key,
+  );
 
   useEffect(() => {
     if (cellSets.loading && !cellSets.error) {
@@ -113,7 +128,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
       && !processingConfig.meta.loadingSettingsError
       && processingConfig[steps[stepIdx].key].enabled
     ) {
-      stepsDisabledByPrefilter.forEach((step) => {
+      disableStepsOnCondition.prefilter.forEach((step) => {
         dispatch(updateProcessingSettings(experimentId, step, { enabled: false }))
         dispatch(saveProcessingSettings(experimentId, step))
       })
@@ -122,22 +137,23 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   }, [preFilteredSamples, processingConfig.meta])
 
   useEffect(() => {
-    if (
-      preFilteredSamples.length > 0
-      && !processingConfig.meta.loading
-      && !processingConfig.meta.loadingSettingsError
-    ) {
-      setDisabledByPrefilter(stepsDisabledByPrefilter.includes(steps[stepIdx].key))
+    if (sampleKeys && sampleKeys.length === 1) {
+      disableStepsOnCondition.unisample.forEach((step) => {
+        dispatch(updateProcessingSettings(experimentId, step, { enabled: false }))
+        dispatch(saveProcessingSettings(experimentId, step))
+      })
     }
-  }, [stepIdx, processingConfig.meta])
+  }, [cellSets])
+
+  useEffect(() => {
+    const applicableFilters = Object.entries(disableStepsOnCondition).filter(([key, value]) => value.includes(steps[stepIdx].key))
+
+    // Get the first value because return of Object.entries is [filterName,[steps]]
+    setApplicableFilters(applicableFilters.map(filter => filter[0]))
+    setStepDisabledByCondition(applicableFilters.length > 0)
+  }, [stepIdx])
 
   const upcomingStepIdxRef = useRef(null);
-
-  const sampleKeys = cellSets.hierarchy?.find(
-    (rootNode) => (rootNode.key === 'sample'),
-  )?.children.map(
-    (child) => child.key,
-  );
 
   // Checks if the step is in the 'completed steps' list we get from the pipeline status
   const isStepComplete = (stepName) => {
@@ -431,7 +447,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
             <Col>
               {steps[stepIdx].multiSample && (
                 <Button
-                  disabled={disabledByPrefilter}
+                  disabled={stepDisabledByCondition}
                   onClick={() => {
                     dispatch(updateProcessingSettings(
                       experimentId,
@@ -572,16 +588,24 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
             return (
               <Space direction='vertical'>
-                {processingConfig[steps[stepIdx].key].enabled === false &&
-                  < Alert
-                    message={
-                      disabledByPrefilter ?
-                        `This filter is disabled because ${preFilteredSamples.join(', ')} ${preFilteredSamples.length > 1 ? 'are' : 'is'} pre-filtered.`
-                        : 'This filter is disabled. You can still modify and save changes, but the filter will not be applied to your data.'
-                    }
-                    type="info"
-                    showIcon
-                  />
+                {processingConfig[steps[stepIdx].key].enabled === false ?
+                  (
+                    stepDisabledByCondition ? (
+                      applicableFilters.map(filter =>
+                        < Alert
+                          message={disabledConditionMessage[filter]}
+                          type="info"
+                          showIcon
+                        />
+                      )
+                    ) : (
+                      < Alert
+                        message={'This filter is disabled. You can still modify and save changes, but the filter will not be applied to your data.'}
+                        type="info"
+                        showIcon
+                      />
+                    )
+                  ) : <></>
                 }
                 { renderWithInnerScroll(() => render(key, experimentId))}
               </Space>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -85,8 +85,8 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   }
 
   const disabledConditionMessage = {
-    prefilter: `Filter disabled because ${preFilteredSamples.join(', ')} ${preFilteredSamples.length > 1 ? 'are' : 'is'} pre-filtered.`,
-    unisample: "Step disabled because there is only one sample"
+    prefilter: `This filter disabled because samples ${preFilteredSamples.join(', ')} ${preFilteredSamples.length > 1 ? 'are' : 'is'} pre-filtered.`,
+    unisample: "This step is disabled as there is only one sample"
   }
 
   const sampleKeys = cellSets.hierarchy?.find(

--- a/src/redux/reducers/differentialExpression/initialState.js
+++ b/src/redux/reducers/differentialExpression/initialState.js
@@ -8,7 +8,7 @@ const initialState = {
     total: 0,
   },
   comparison: {
-    type: 'between',
+    type: 'within',
     group: {
       between: {
         cellSet: null,


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-827

#### Link to staging deployment URL 

Multisample, with prefiltered data :
https://ui-agi-uni-multi.scp-staging.biomage.net/experiments/e52b39624588791a7889e39c617f669e/data-processing
Unisample (data integration step disabled) :
https://ui-agi-uni-multi.scp-staging.biomage.net/experiments/7d9318d157a6b17d3d6caec23a25cc86/data-processing

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Change option in gene expression to compare in sample by default
- Remove "Copy to all sample" button in data processing if there is only 1 sample
- Disable "Copy to all sample" button in data processing if "auto" is chosen.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [x] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
