### PR TITLE
Enabled/disabled doesn't trigger the "save changes" button

### DIFF
--- a/src/components/plots/Header.jsx
+++ b/src/components/plots/Header.jsx
@@ -84,6 +84,7 @@ const Header = (props) => {
       router.events.off('routeChangeStart', showPopupWhenUnsaved);
     };
   }, [router.asPath, router.events, saved]);
+
   const { data } = useSWR(
     `/v1/experiments/${experimentId}`,
     getFromApiExpectOK,

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -438,7 +438,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                       steps[stepIdx].key,
                       { enabled: !processingConfig[steps[stepIdx].key]?.enabled },
                     ));
-                    dispatchDebounce(saveProcessingSettings(experimentId, steps[stepIdx].key));
+                    setChangesOutstanding(true);
                   }}>
                   {
                     !processingConfig[steps[stepIdx].key]?.enabled

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -438,6 +438,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                       steps[stepIdx].key,
                       { enabled: !processingConfig[steps[stepIdx].key]?.enabled },
                     ));
+                    dispatchDebounce(saveProcessingSettings(experimentId, steps[stepIdx].key));
                     setChangesOutstanding(true);
                   }}>
                   {

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -438,7 +438,6 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                       steps[stepIdx].key,
                       { enabled: !processingConfig[steps[stepIdx].key]?.enabled },
                     ));
-                    dispatchDebounce(saveProcessingSettings(experimentId, steps[stepIdx].key));
                     setChangesOutstanding(true);
                   }}>
                   {


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-864

#### Link to staging deployment URL 
https://ui-marcellp-ui224.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
Changed disabling a filter to not save automatically, instead, it is only updated and the user must press `Save changes` for the config changes to be propagated like with all other config changes.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
