### PR TITLE
changed default sandbox value when running locally

### DIFF
--- a/src/utils/ssr/getAuthenticationInfo.js
+++ b/src/utils/ssr/getAuthenticationInfo.js
@@ -58,7 +58,7 @@ const getAuthenticationInfo = async () => {
     ),
   ]);
 
-  const sandboxId = process.env.SANDBOX_ID || 'develop';
+  const sandboxId = process.env.SANDBOX_ID || 'default';
 
   /**
    * NOTE: if no environment is supplied (i.e. local development)


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

Changed the default sandbox id (only used in local development) to `default` instead of develop following the same change in `userpoolclients.yaml` in IAC. 

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
