### PR TITLE
fix single quote

### DIFF
--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -42,7 +42,7 @@ const fastLoad = (message) => (
     </div>
     <p>
       <Text>
-        {message || 'We&apos;re getting your data...'}
+        {message || "We're getting your data..."}
       </Text>
     </p>
   </>


### PR DESCRIPTION
`&apos;` doesn't seem to work inside quotes. Viewed on chrome:

![image](https://user-images.githubusercontent.com/15719520/117083420-826dcc00-acf9-11eb-8357-042772efffff.png)
