### PR TITLE
pinning ubuntu versions used in workflows to allow failures when late…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build website
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CI: "true"
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   build-docker:
     name: Build Docker container
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
     steps:
       - id: checkout
@@ -128,7 +128,7 @@ jobs:
 
   deploy:
     name: Deploy to Kubernetes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-docker
     strategy:
       max-parallel: 1


### PR DESCRIPTION
Pinning the ubuntu versions used in github actions to avoid future failures due to latest tag being updated into something that breaks our builds.