### PR TITLE
Fix error status bug

### DIFF
--- a/src/__test__/utils/processUpload.test.js
+++ b/src/__test__/utils/processUpload.test.js
@@ -221,10 +221,17 @@ describe('processUpload (in development)', () => {
       (status) => status === UploadStatus.UPLOAD_ERROR,
     );
 
+    const uploadedFileStatuses = filesStatuses.filter(
+      (status) => status === UploadStatus.UPLOADED,
+    );
+
     // There are 3 files actions with status uploading
     expect(uploadingFileStatuses.length).toEqual(6);
 
     // There are 3 files actions with status upload error
     expect(errorFileStatuses.length).toEqual(3);
+
+    // There are no file actions with status successfully uploaded
+    expect(uploadedFileStatuses.length).toEqual(0);
   });
 });

--- a/src/__test__/utils/processUpload.test.js
+++ b/src/__test__/utils/processUpload.test.js
@@ -183,11 +183,18 @@ describe('processUpload (in development)', () => {
       (status) => status === UploadStatus.FILE_READ_ERROR,
     );
 
+    const uploadedFileStatuses = filesStatuses.filter(
+      (status) => status === UploadStatus.UPLOADED,
+    );
+
     // There are 3 files actions with status uploading
     expect(uploadingFileStatuses.length).toEqual(6);
 
     // There are 3 files actions with status upload error
     expect(errorFileStatuses.length).toEqual(3);
+
+    // There are no file actions with status successfully uploaded
+    expect(uploadedFileStatuses.length).toEqual(0);
   });
 
   it('Updates redux correctly when there are file upload errors', async () => {

--- a/src/utils/processUpload.js
+++ b/src/utils/processUpload.js
@@ -74,6 +74,8 @@ const compressAndUploadSingleFile = async (
         { upload: { status: fileErrorStatus } },
       ),
     );
+
+    return;
   }
 
   try {
@@ -86,6 +88,8 @@ const compressAndUploadSingleFile = async (
         { upload: { status: UploadStatus.UPLOAD_ERROR } },
       ),
     );
+
+    return;
   }
 
   dispatch(


### PR DESCRIPTION
# Background
#### Link to issue 
No ticket created (should I?)

#### Link to staging deployment URL 
https://ui-martinfosco-ui251.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
When there was an upload error the status dispatch was overwritten by a successful upload dispatch.

- To fix it return when the catch ends.
- Add check in the unit tests so that we make sure this doesn't happen again.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
