### PR TITLE
Fix intermitent failures in violin plot tests

### DIFF
--- a/src/__test__/components/plots-and-tables/ViolinPlotIndex.test.jsx
+++ b/src/__test__/components/plots-and-tables/ViolinPlotIndex.test.jsx
@@ -20,6 +20,7 @@ import ViolinIndex from '../../../pages/experiments/[experimentId]/plots-and-tab
 import * as generateViolinSpec from '../../../utils/plotSpecs/generateViolinSpec';
 import { fetchCachedWork } from '../../../utils/cacheRequest';
 import { mockCellSets1 as cellSets } from '../../test-utils/cellSets.mock';
+import { expectStringInVegaCanvas } from '../../test-utils/vega-utils';
 
 jest.mock('localforage');
 enableFetchMocks();
@@ -91,18 +92,6 @@ describe('ViolinIndex', () => {
     await rtl.waitFor(() => expect(fetchCachedWork).toHaveBeenCalledTimes(2));
   };
 
-  const expectOcurrencesInCanvas = async (str, ocurrences) => {
-    const getCanvas = () => rtl.screen.getByRole('graphics-document').children[0];
-    // eslint-disable-next-line no-underscore-dangle
-    const getCanvasStrings = (canvas) => canvas.getContext('2d').__getEvents()
-      .filter((event) => event.type === 'fillText')
-      .map((event) => event.props.text);
-    const canvas = getCanvas();
-    await rtl.waitFor(() => {
-      const strings = getCanvasStrings(canvas);
-      expect(strings.filter((inCanvas) => inCanvas.includes(str)).length).toBe(ocurrences);
-    });
-  };
   it('loads by default the gene with the highest dispersion, allows another to be selected, and updates the plot\'s title', async () => {
     await renderViolinIndex();
 
@@ -121,7 +110,7 @@ describe('ViolinIndex', () => {
     expect(store.getState().componentConfig[plotUuid].config.shownGene).toBe(newGeneShown);
 
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(1));
-    await expectOcurrencesInCanvas(newGeneShown, 1);
+    await expectStringInVegaCanvas(newGeneShown, 1);
   });
 
   it('allows selection of the grouping/points, defaulting to louvain and All', async () => {
@@ -157,12 +146,12 @@ describe('ViolinIndex', () => {
     expect(inputFields[1].parentNode.parentNode).toHaveTextContent('All');
 
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(1));
-    await expectOcurrencesInCanvas('cluster a', 1);
+    await expectStringInVegaCanvas('cluster a', 1);
 
     // Testing the effect of grouping by sample
     store.dispatch(updatePlotConfig(plotUuid, { selectedCellSet: 'sample' }));
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(2));
-    await expectOcurrencesInCanvas('Sample 1', 1);
+    await expectStringInVegaCanvas('Sample 1', 1);
   });
   it('has a Data Tranformation panel', async () => {
     await renderViolinIndex();
@@ -175,13 +164,13 @@ describe('ViolinIndex', () => {
     // Normalization
     const weAreAbleToGetRawValue = false; // TO-DO
     if (weAreAbleToGetRawValue) {
-      await expectOcurrencesInCanvas('Normalised Expression', 1);
+      await expectStringInVegaCanvas('Normalised Expression', 1);
       const radioButtons = rtl.getAllByRole(panelContainer, 'radio');
       expect(radioButtons[0].parentNode.parentNode).toHaveTextContent('Normalised');
       expect(radioButtons[1].parentNode.parentNode).toHaveTextContent('Raw values');
       userEvent.click(radioButtons[1]);
       await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(2));
-      await expectOcurrencesInCanvas('Raw Expression', 1);
+      await expectStringInVegaCanvas('Raw Expression', 1);
     }
 
     // Slider
@@ -232,7 +221,7 @@ describe('ViolinIndex', () => {
     expect(radioButtons[1].parentNode.parentNode).toHaveTextContent('Hide');
 
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(1));
-    await expectOcurrencesInCanvas('cluster a', 1);
+    await expectStringInVegaCanvas('cluster a', 1);
 
     userEvent.click(radioButtons[0]);
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(2));
@@ -242,7 +231,7 @@ describe('ViolinIndex', () => {
     expect(radioButtons[2]).toBeChecked();
     expect(radioButtons[2].parentNode.parentNode).toHaveTextContent('Top');
 
-    await expectOcurrencesInCanvas('cluster a', 2);
+    await expectStringInVegaCanvas('cluster a', 2);
   });
 
   it('allows the gene name to be overriden as the title and clears the override upon new gene selection', async () => {
@@ -258,15 +247,14 @@ describe('ViolinIndex', () => {
     let panelContainer = mainSchema.parentElement;
     const titleInput = rtl.getByRole(panelContainer, 'textbox');
     expect(titleInput).toHaveValue('');
-    await expectOcurrencesInCanvas('MockGeneWithHighestDispersion', 1);
+    await expectStringInVegaCanvas('MockGeneWithHighestDispersion', 1);
 
-    const titleOverride = 'Title Override';
+    const titleOverride = '€'; // Single character so that useUpdateThrottled does not mess with the tests
     generateSpecSpy.mockClear();
     userEvent.type(titleInput, titleOverride);
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalled());
-    await expectOcurrencesInCanvas('MockGeneWithHighestDispersion', 0);
-    // Cannot look for title ocurrence because of re-draw being triggered by firts letters typed
-    // expect(ocurrencesInCanvas(titleOverride)).toBe(1);
+    await expectStringInVegaCanvas('MockGeneWithHighestDispersion', 0);
+    await expectStringInVegaCanvas(titleOverride, 1);
 
     const geneSelection = tabs.find((tab) => tab.textContent === 'Gene Selection');
     panelContainer = geneSelection.parentNode;
@@ -277,7 +265,7 @@ describe('ViolinIndex', () => {
     userEvent.type(geneInput, `{selectall}{del}${newGeneShown}`);
     userEvent.click(rtl.getByRole(panelContainer, 'button'));
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalled());
-    await expectOcurrencesInCanvas(newGeneShown, 1);
+    await expectStringInVegaCanvas(newGeneShown, 1);
   });
 
   it.skip('has an Axis and Margins panel (TO-DO)', async () => {
@@ -301,7 +289,7 @@ describe('ViolinIndex', () => {
     expect(radioButtons[1].parentNode.parentNode).toHaveTextContent('Hide');
 
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(1));
-    await expectOcurrencesInCanvas('cluster a', 1);
+    await expectStringInVegaCanvas('cluster a', 1);
 
     userEvent.click(radioButtons[0]);
     await rtl.waitFor(() => expect(generateSpecSpy).toHaveBeenCalledTimes(2));
@@ -311,6 +299,6 @@ describe('ViolinIndex', () => {
     expect(radioButtons[2]).toBeChecked();
     expect(radioButtons[2].parentNode.parentNode).toHaveTextContent('Top');
 
-    await expectOcurrencesInCanvas('cluster a', 2);
+    await expectStringInVegaCanvas('cluster a', 2);
   });
 });

--- a/src/__test__/test-utils/vega-utils.js
+++ b/src/__test__/test-utils/vega-utils.js
@@ -1,0 +1,23 @@
+import * as rtl from '@testing-library/react';
+
+const expectStringInVegaCanvas = async (str, ocurrences, waitForOptions) => {
+  const getCanvas = () => rtl.screen.getByRole('graphics-document').children[0];
+  // eslint-disable-next-line no-underscore-dangle
+  const getCanvasStrings = (canvas) => canvas.getContext('2d').__getEvents()
+    .filter((event) => event.type === 'fillText')
+    .map((event) => event.props.text);
+  const canvas = getCanvas();
+  const onTimeout = (error) => {
+    console.log(`Could not find ${ocurrences} ocurrences of "${str}" in the canvas. I found these: ${getCanvasStrings(canvas)}`);
+    return error;
+  };
+  await rtl.waitFor(() => {
+    const strings = getCanvasStrings(canvas);
+    expect(strings.filter((inCanvas) => inCanvas.includes(str)).length).toBe(ocurrences);
+  }, { ...waitForOptions, onTimeout });
+};
+
+export {
+  // eslint-disable-next-line import/prefer-default-export
+  expectStringInVegaCanvas,
+};


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-898
#### Link to staging deployment URL 
N/A
#### Links to any Pull Requests related to this
N/A
#### Anything else the reviewers should know about the changes here

# Changes
### Code changes
* Make checking for strings in vega canvases more robust
* Make the reporting of failed tests on canvas strings less uselessly verbose
# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
