### PR TITLE
disable of data integration and dim red separately

### DIFF
--- a/src/components/data-processing/DataIntegration/CalculationConfig.jsx
+++ b/src/components/data-processing/DataIntegration/CalculationConfig.jsx
@@ -34,7 +34,10 @@ const { Panel } = Collapse;
 
 const CalculationConfig = (props) => {
   const {
-    experimentId, onPipelineRun, disabled,
+    experimentId,
+    onPipelineRun,
+    disabled,
+    disableDataIntegration,
   } = props;
   const FILTER_UUID = 'dataIntegration';
 
@@ -102,7 +105,7 @@ const CalculationConfig = (props) => {
         config={dataIntegration.methodSettings.seuratv4}
         onUpdate={updateSettings}
         onChange={() => setChangesOutstanding(true)}
-        disabled={disabled}
+        disabled={disableDataIntegration || disabled}
       />
     ),
   };
@@ -146,7 +149,7 @@ const CalculationConfig = (props) => {
               <Select
                 value={dataIntegration.method}
                 onChange={(val) => updateSettings({ dataIntegration: { method: val } })}
-                disabled={disabled}
+                disabled={disableDataIntegration || disabled}
               >
                 {
                   methods.map((el) => (
@@ -197,10 +200,11 @@ const CalculationConfig = (props) => {
             <Form.Item label='Exclude genes categories'>
               <Tooltip title='Normalization can be biased by certain gene categories such the ones listed here.
               Checking them will ignore those categories.
-              For example, cell cycle genes should be removed if sampling timepoints occured throughout the day. 
-              Those genes can otherwise introduces within-cell-type heterogeneity that can obscure the differences 
+              For example, cell cycle genes should be removed if sampling timepoints occured throughout the day.
+              Those genes can otherwise introduces within-cell-type heterogeneity that can obscure the differences
               in expression between cell types.
-              This is not implemented yet'>
+              This is not implemented yet'
+              >
                 <QuestionCircleOutlined />
               </Tooltip>
               <Checkbox.Group
@@ -280,7 +284,7 @@ const CalculationConfig = (props) => {
           </div>
         </Form>
       </Panel>
-    </Collapse >
+    </Collapse>
   );
 };
 
@@ -288,10 +292,12 @@ CalculationConfig.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  disableDataIntegration: PropTypes.bool,
 };
 
 CalculationConfig.defaultProps = {
   disabled: false,
+  disableDataIntegration: false,
 };
 
 export default CalculationConfig;

--- a/src/components/data-processing/DataIntegration/DataIntegration.jsx
+++ b/src/components/data-processing/DataIntegration/DataIntegration.jsx
@@ -34,6 +34,12 @@ const DataIntegration = (props) => {
   const [plot, setPlot] = useState(null);
   const cellSets = useSelector((state) => state.cellSets);
 
+  const sampleKeys = cellSets.hierarchy?.find(
+    (rootNode) => (rootNode.key === 'sample'),
+  )?.children.map(
+    (child) => child.key,
+  );
+
   const filterName = 'dataIntegration';
   const configureEmbeddingFilterName = 'configureEmbedding';
 
@@ -368,6 +374,7 @@ const DataIntegration = (props) => {
             config={calculationConfig}
             onPipelineRun={onPipelineRun}
             disabled={stepDisabled}
+            disableDataIntegration={sampleKeys && sampleKeys.length === 1}
           />
           <Collapse>
             <Panel header='Plot styling' key='styling'>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -81,7 +81,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
   const disableStepsOnCondition = {
     prefilter: ['classifier'],
-    unisample: ['dataIntegration']
+    unisample: []
   }
 
   const disabledConditionMessage = {


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-940
https://this-is-biomage.slack.com/archives/C014YMUT6GN/p1621021422046600

#### Link to staging deployment URL 

Coming soon

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Enable data integration *filter* for unisample
- Disable data integration *settings* if unisample
- Dimensionality reduction is always enabled.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
