### PR TITLE
Fix bug in metadata tracks

### DIFF
--- a/src/redux/actions/samples/updateSample.js
+++ b/src/redux/actions/samples/updateSample.js
@@ -1,4 +1,6 @@
 import moment from 'moment';
+import _ from 'lodash';
+
 import saveSamples from './saveSamples';
 
 import {
@@ -13,7 +15,7 @@ const updateSample = (
   sampleUuid,
   diff,
 ) => async (dispatch, getState) => {
-  const sample = getState().samples[sampleUuid];
+  const sample = _.cloneDeep(getState().samples[sampleUuid]);
 
   // eslint-disable-next-line no-param-reassign
   diff.lastModified = moment().toISOString();


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
There was a bug in metadata tracks when setting up two samples, the same value set for one metadata track in a sample would be applied to the other sample's track.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
