### PR TITLE
Select the proper redirect url BIOMAGE-997

### DIFF
--- a/src/utils/amplify-config.js
+++ b/src/utils/amplify-config.js
@@ -2,11 +2,6 @@ import Environment, { ssrGetCurrentEnvironment } from './environment';
 
 const configure = (userPoolId, identityPoolId, userPoolClientDetails) => {
   const currentEnvironment = ssrGetCurrentEnvironment();
-  // console.log('======');
-  // console.log(currentEnvironment);
-  // console.log(userPoolId);
-  // console.log(identityPoolId);
-  // console.log(userPoolClientDetails);
 
   const bucketName = `biomage-originals-${currentEnvironment}`;
 

--- a/src/utils/amplify-config.js
+++ b/src/utils/amplify-config.js
@@ -2,6 +2,11 @@ import Environment, { ssrGetCurrentEnvironment } from './environment';
 
 const configure = (userPoolId, identityPoolId, userPoolClientDetails) => {
   const currentEnvironment = ssrGetCurrentEnvironment();
+  // console.log('======');
+  // console.log(currentEnvironment);
+  // console.log(userPoolId);
+  // console.log(identityPoolId);
+  // console.log(userPoolClientDetails);
 
   const bucketName = `biomage-originals-${currentEnvironment}`;
 
@@ -15,6 +20,10 @@ const configure = (userPoolId, identityPoolId, userPoolClientDetails) => {
       },
     },
   };
+  const redirectProtocol = (process.env.NODE_ENV === 'development') ? 'http:' : 'https:';
+  const usingProtocol = (url) => url.startsWith(redirectProtocol);
+  const signInRedirect = userPoolClientDetails.CallbackURLs.filter(usingProtocol)[0];
+  const signOutRedirect = userPoolClientDetails.LogoutURLs.filter(usingProtocol)[0];
 
   const authConfig = {
     Auth: {
@@ -29,8 +38,8 @@ const configure = (userPoolId, identityPoolId, userPoolClientDetails) => {
       oauth: {
         domain: userPoolClientDetails.Domain,
         scope: userPoolClientDetails.AllowedOAuthScopes,
-        redirectSignIn: userPoolClientDetails.CallbackURLs[0],
-        redirectSignOut: userPoolClientDetails.LogoutURLs[0],
+        redirectSignIn: signInRedirect,
+        redirectSignOut: signOutRedirect,
         responseType: userPoolClientDetails.AllowedOAuthFlows[0],
       },
     },


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-997
#### Link to staging deployment URL 
N/A Only affects local development and https://ui-default.scp-staging.biomage.net
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes
The user pool configuration defines two urls for App client `biomage-cellscope-cluster-default`, one for the `ui-default` environment and one for localhost. We need to select the appropriate one so that we don't land in the wrong place after logging on.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
