### PR TITLE
Clarify metadata showing unfiltered cell numbers

### DIFF
--- a/src/__test__/components/data-exploration/cell-sets-tool/CellSetsTool.test.jsx
+++ b/src/__test__/components/data-exploration/cell-sets-tool/CellSetsTool.test.jsx
@@ -285,7 +285,7 @@ describe('CellSetsTool', () => {
     // We should have found the union operation.
     expect.hasAssertions();
   });
-  it('selected cell sets show selected in both tabs', () => {
+  it('selected cell sets show selected in both tabs including disclaimer', () => {
     const store = mockStore(
       {
         ...storeState,
@@ -312,7 +312,7 @@ describe('CellSetsTool', () => {
     const text = component.find('#selectedCellSets').first();
     expect(text.text()).toEqual('3 cells selected');
     tabs.props().onChange('metadataCategorical');
-    expect(text.text()).toEqual('4 cells selected');
+    expect(text.text()).toEqual('4 cells selected (including filtered cells)');
     tabs.props().onChange('cellSets');
     expect(text.text()).toEqual('3 cells selected');
   });

--- a/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
+++ b/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
@@ -133,6 +133,7 @@ const CellSetsTool = (props) => {
             {numSelected === 1 ? '' : 's'}
             {' '}
             selected
+            {activeTab === 'metadataCategorical' && ' (including filtered cells)'}
           </Text>
         </Space>
       );


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-962

#### Link to staging deployment URL
https://ui-marcellp-ui270-apidevelop-.scp-staging.biomage.net/experiments/marcellp-ui270-apidevelop--e52b39624588791a7889e39c617f669e/data-processing

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
We have decided that the best way to address this straight away is to make it less confusing by explicitly stating that this includes filtered cells as well. We are creating a ticket that addresses the actual problem in R after the MVP.

# Changes
### Code changes
Added a text to clarify that the number of cells in the set includes filtered cells.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
