### PR TITLE
not reloading experiments for old experiments without project UUID

### DIFF
--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -6,6 +6,7 @@ import { Button, Space } from 'antd';
 import ReactResizeDetector from 'react-resize-detector';
 import 'react-mosaic-component/react-mosaic-component.css';
 
+import { validate } from 'uuid';
 import { createProject, loadProjects } from '../../redux/actions/projects';
 import { loadExperiments } from '../../redux/actions/experiments';
 
@@ -32,14 +33,22 @@ const DataManagementPage = ({ route }) => {
   const existingExperiments = activeProject?.experiments
     .map((experimentId) => experiments[experimentId]);
 
+  const experimentIds = new Set(experiments.ids);
+  const experimentsAreLoaded = activeProject?.experiments
+    .every((experimentId) => experimentIds.has(experimentId));
+  const isUuid = (uuid) => validate(uuid);
+
+  // const experimentsAreLoaded = (project, experiments) => {}
   useEffect(() => {
     if (projectsList.ids.length === 0) dispatch(loadProjects());
   }, []);
 
   useEffect(() => {
-    if (!activeProjectUuid || activeProject?.experiments.every(
-      (experimentId) => experiments.ids.includes(experimentId),
-    )) return;
+    // old experiments don't have a project so the activeProjectUuid will actually be an experiment
+    // ID so the experiments load will fail this should be addressed by migrating experiments
+    // for now, if the activeProjectUuid is not a Uuid it means that it's an old experiment
+    // and we should not try to load the experiments with it
+    if (!activeProjectUuid || experimentsAreLoaded || !isUuid(activeProjectUuid)) return;
 
     dispatch(loadExperiments(activeProjectUuid));
   }, [activeProject]);


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1017

#### Link to staging deployment URL 

https://ui-old-experiments.scp-staging.biomage.net/data-management

# Changes
### Code changes

 Old experiments don't have a project so the activeProjectUuid will actually be an experiment  ID so the experiments load will fail this should be addressed by migrating experiments  for now, if the activeProjectUuid is not a Uuid it means that it's an old experiment and we should not try to load the experiments with it

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR
![image](https://user-images.githubusercontent.com/2961095/119692249-8cdc3b00-be4b-11eb-95ce-3f0e5100a297.png)
