### PR TITLE
[BIOMAGE-1024] - Fix long project name hiding project controls

### DIFF
--- a/src/components/EditableField.jsx
+++ b/src/components/EditableField.jsx
@@ -128,7 +128,7 @@ const EditableField = (props) => {
   return (
     <>
       <Space direction='vertical'>
-        <Space style={{ alignItems: 'flex-start' }}>
+        <Space align='start'>
           {renderEditState()}
           {
             deleteEnabled

--- a/src/components/EditableField.jsx
+++ b/src/components/EditableField.jsx
@@ -128,7 +128,7 @@ const EditableField = (props) => {
   return (
     <>
       <Space direction='vertical'>
-        <Space>
+        <Space style={{ alignItems: 'flex-start' }}>
           {renderEditState()}
           {
             deleteEnabled

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
-  Table, Typography, Space, Tooltip, PageHeader, Button, Input, Progress,
+  Table, Typography, Space, Tooltip, PageHeader, Button, Input, Progress, Row, Col,
 } from 'antd';
 import { useRouter } from 'next/router';
 import { useSelector, useDispatch } from 'react-redux';
@@ -47,7 +47,7 @@ import '../../utils/css/hover.css';
 import runGem2s from '../../redux/actions/pipeline/runGem2s';
 import loadBackendStatus from '../../redux/actions/experimentSettings/loadBackendStatus';
 
-const { Text, Paragraph } = Typography;
+const { Title, Text, Paragraph } = Typography;
 
 const ProjectDetails = ({ width, height }) => {
   const defaultNA = 'N.A.';
@@ -646,69 +646,79 @@ const ProjectDetails = ({ width, height }) => {
         onCancel={() => setUploadDetailsModalVisible(false)}
       />
       <div width={width} height={height}>
-        <PageHeader
-          title={activeProject.name}
-          extra={[
-            <Button
-              disabled={projects.ids.length === 0}
-              onClick={() => setUploadModalVisible(true)}
-            >
-              Add samples
-            </Button>,
-            <Button
-              disabled={
-                projects.ids.length === 0
+        <Space direction='vertical' style={{ width: '100%', padding: '8px 4px' }}>
+          <Row style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Title level={3}>{activeProject.name}</Title>
+            <Space>
+              <Button
+                disabled={projects.ids.length === 0}
+                onClick={() => setUploadModalVisible(true)}
+              >
+                Add samples
+              </Button>
+              <Button
+                disabled={
+                  projects.ids.length === 0
                 || activeProject?.samples?.length === 0
                 || isAddingMetadata
-              }
-              onClick={() => {
-                setIsAddingMetadata(true);
-                createMetadataColumn();
-              }}
-            >
-              Add metadata
-            </Button>,
-            <Button
-              type='primary'
-              disabled={
-                projects.ids.length === 0
+                }
+                onClick={() => {
+                  setIsAddingMetadata(true);
+                  createMetadataColumn();
+                }}
+              >
+                Add metadata
+              </Button>
+              <Button
+                type='primary'
+                disabled={
+                  projects.ids.length === 0
                 || activeProject?.samples?.length === 0
                 || !canLaunchAnalysis
+                }
+                onClick={() => openAnalysisModal()}
+              >
+                Launch analysis
+              </Button>
+            </Space>
+          </Row>
+
+          <Row>
+            <Col>
+              {
+                activeProjectUuid && (
+                  <Space direction='vertical' size='small'>
+                    <Text type='secondary'>{`ID : ${activeProjectUuid}`}</Text>
+                    <Text strong>Description:</Text>
+                    <Paragraph
+                      editable={{ onChange: changeDescription }}
+                    >
+                      {activeProject.description}
+
+                    </Paragraph>
+                  </Space>
+                )
               }
-              onClick={() => openAnalysisModal()}
-            >
-              Launch analysis
-            </Button>,
-          ]}
-        >
-          {
-            activeProjectUuid && (
-              <Space direction='vertical' size='small'>
-                <Text type='secondary'>{`ID : ${activeProjectUuid}`}</Text>
-                <Text strong>Description:</Text>
-                <Paragraph
-                  editable={{ onChange: changeDescription }}
-                >
-                  {activeProject.description}
+            </Col>
+          </Row>
 
-                </Paragraph>
-              </Space>
-            )
-          }
-        </PageHeader>
-
-        <Table
-          size='small'
-          scroll={{
-            x: 'max-content',
-            y: height - 250,
-          }}
-          bordered
-          columns={tableColumns}
-          dataSource={tableData}
-          sticky
-          pagination={false}
-        />
+          <Row>
+            <Col>
+              <Table
+                size='small'
+                scroll={{
+                  x: 'max-content',
+                  y: height - 250,
+                }}
+                bordered
+                columns={tableColumns}
+                dataSource={tableData}
+                sticky
+                pagination={false}
+              />
+            </Col>
+          </Row>
+        </Space>
       </div>
     </>
   );

--- a/src/components/data-management/ProjectsListContainer.jsx
+++ b/src/components/data-management/ProjectsListContainer.jsx
@@ -90,8 +90,8 @@ const ProjectsListContainer = (props) => {
                 layout='horizontal'
                 size='small'
                 column={1}
-                colon=''
-                title={(
+              >
+                <Descriptions.Item contentStyle={{ fontWeight: 700, fontSize: 16 }}>
                   <EditableField
                     value={projects[uuid].name}
                     onAfterSubmit={(name) => {
@@ -110,8 +110,7 @@ const ProjectsListContainer = (props) => {
                       ).isValid
                     }
                   />
-                )}
-              >
+                </Descriptions.Item>
                 <Descriptions.Item
                   labelStyle={{ fontWeight: 'bold' }}
                   label='Samples'

--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -65,11 +65,16 @@ const DataManagementPage = ({ route }) => {
     'Projects List': {
       toolbarControls: [],
       component: (width, height) => (
-        <Space direction='vertical' style={{ width: '100%', overflowY: 'scroll' }}>
+        <Space
+          direction='vertical'
+          style={{ width: '100%' }}
+        >
           <Button type='primary' block onClick={() => setNewProjectModalVisible(true)}>
             Create New Project
           </Button>
-          <ProjectsListContainer height={height} />
+          <Space direction='vertical' style={{ width: '100%', overflowY: 'scroll' }}>
+            <ProjectsListContainer height={height} />
+          </Space>
         </Space>
       ),
     },


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1024

#### Link to staging deployment URL 

https://ui-agi-ui284.scp-staging.biomage.net/data-management

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Change project name to be put into a `Descriptions.Item` text

P.S. As a celebration for the 1024th ticket, I've added changes that will stick the "Create New Button" to the top of Projects List, so we don't have to scroll all the way back up again to create new changes.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
