### PR TITLE
[BIOMAGE-1028] - use "NotCreated" PipelineStatus in the UI

### DIFF
--- a/src/__test__/pages/experiments/[experimentId]/data-processing/index.test.jsx
+++ b/src/__test__/pages/experiments/[experimentId]/data-processing/index.test.jsx
@@ -133,7 +133,7 @@ const getStore = (settings = {}) => {
 describe('DataProcessingPage', () => {
   const experimentData = {};
 
-  it('renders correctly', () => {
+  it('renders correctly after a successful pipeline run', () => {
     const store = getStore({
       experimentSettings: {
         backendStatus: {
@@ -156,10 +156,10 @@ describe('DataProcessingPage', () => {
     const card = page.find('Card');
     expect(card.length).toEqual(1);
 
-    const runDataProcessingButton = page.find('#runDataProcessingButton').filter('Button');
+    const runDataProcessingButton = page.find('#runQCPipelineButton').filter('Button');
     expect(runDataProcessingButton.length).toEqual(1);
 
-    // Run filter is disabled initially
+    // Run filter is disabled after pipeline is run successfully
     expect(runDataProcessingButton.at(0).props().disabled).toEqual(true);
   });
 
@@ -174,7 +174,7 @@ describe('DataProcessingPage', () => {
       </Provider>,
     );
 
-    const runDataProcessingButton = page.find('#runDataProcessingButton').filter('Button').at(0);
+    const runDataProcessingButton = page.find('#runQCPipelineButton').filter('Button').at(0);
 
     expect(runDataProcessingButton.props().disabled).toEqual(false);
     expect(runDataProcessingButton.text()).toEqual('Run Data Processing');
@@ -205,7 +205,7 @@ describe('DataProcessingPage', () => {
 
     page.update();
 
-    const runDataProcessingButton = page.find('#runDataProcessingButton').filter('Button').at(0);
+    const runDataProcessingButton = page.find('#runQCPipelineButton').filter('Button').at(0);
 
     // Run filter is enabled after changes take place
     expect(runDataProcessingButton.props().disabled).toEqual(false);
@@ -213,7 +213,7 @@ describe('DataProcessingPage', () => {
 
     act(() => {
       page
-        .find('#runDataProcessingButton').filter('Button')
+        .find('#runQCPipelineButton').filter('Button')
         .at(0).props()
         .onClick();
     });
@@ -224,7 +224,7 @@ describe('DataProcessingPage', () => {
     await waitForActions(store, [EXPERIMENT_SETTINGS_BACKEND_STATUS_LOADING]);
 
     // Run filter is disabled after triggering the pipeline
-    expect(page.find('#runDataProcessingButton').filter('Button').at(0).props().disabled).toEqual(true);
+    expect(page.find('#runQCPipelineButton').filter('Button').at(0).props().disabled).toEqual(true);
   });
 
   it('preFiltered on a sample disables filter', async () => {
@@ -249,7 +249,6 @@ describe('DataProcessingPage', () => {
       </Provider>,
     );
 
-    // Run filter button is disabled on the first
-    expect(page.find('#runDataProcessingButton').filter('Button').at(0).props().disabled).toEqual(true);
+    expect(page.find('#runQCPipelineButton').filter('Button').at(0).props().disabled).toEqual(true);
   });
 });

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -33,6 +33,7 @@ import PlatformError from '../../../../components/PlatformError';
 
 import StepsIndicator from '../../../../components/data-processing/StepsIndicator';
 import StatusIndicator from '../../../../components/data-processing/StatusIndicator';
+import pipelineStatusValues from '../../../../utils/pipelineStatusValues';
 
 import SingleComponentMultipleDataContainer from '../../../../components/SingleComponentMultipleDataContainer';
 import { loadProcessingSettings, updateProcessingSettings, saveProcessingSettings } from '../../../../redux/actions/experimentSettings';
@@ -59,10 +60,10 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   const samples = useSelector((state) => state.samples)
 
   const pipelineStatusKey = pipelineStatus?.status;
-  const pipelineRunning = pipelineStatusKey === 'RUNNING';
+  const pipelineRunning = pipelineStatusKey === pipelineStatusValues.RUNNING;
 
   // Pipeline is not loaded (either running or in an errored state)
-  const pipelineErrors = ['FAILED', 'TIMED_OUT', 'ABORTED'];
+  const pipelineErrors = [pipelineStatusValues.FAILED, pipelineStatusValues.TIMED_OUT, pipelineStatusValues.ABORTED];
   const pipelineNotFinished = pipelineRunning || pipelineErrors.includes(pipelineStatusKey);
 
   const completedSteps = pipelineStatus?.completedSteps;
@@ -76,6 +77,10 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   const [preFilteredSamples, setPreFilteredSamples] = useState([])
   const [stepDisabledByCondition, setStepDisabledByCondition] = useState(false)
   const carouselRef = useRef(null);
+
+  const canRunQCPipeline = pipelineStatusKey === pipelineStatusValues.NOT_CREATED
+    || changesOutstanding
+    || pipelineErrors.includes(pipelineStatusKey)
 
   const disableStepsOnCondition = {
     prefilter: ['classifier'],
@@ -487,13 +492,13 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
             <Col>
               {steps[stepIdx].multiSample && (
                 <Button
-                  id='runFilterButton'
-                  data-testid='runFilterButton'
+                  id='runDataProcessingButton'
+                  data-testid='runDataProcessingButton'
                   type='primary'
                   onClick={() => { onPipelineRun(steps[stepIdx].key) }}
-                  disabled={!pipelineErrors.includes(pipelineStatusKey) && !changesOutstanding}
+                  disabled={!canRunQCPipeline}
                 >
-                  {pipelineErrors.includes(pipelineStatusKey) ? 'Run Data Processing' : 'Save changes'}
+                  {pipelineStatusKey === pipelineStatusValues.NOT_CREATED ? 'Run Data Processing' : 'Save Changes'}
                 </Button>
               )}
             </Col>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -492,8 +492,8 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
             <Col>
               {steps[stepIdx].multiSample && (
                 <Button
-                  id='runDataProcessingButton'
-                  data-testid='runDataProcessingButton'
+                  id='runQCPipelineButton'
+                  data-testid='runQCPipelineButton'
                   type='primary'
                   onClick={() => { onPipelineRun(steps[stepIdx].key) }}
                   disabled={!canRunQCPipeline}

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -498,7 +498,11 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                   onClick={() => { onPipelineRun(steps[stepIdx].key) }}
                   disabled={!canRunQCPipeline}
                 >
-                  {pipelineStatusKey === pipelineStatusValues.NOT_CREATED ? 'Run Data Processing' : 'Save Changes'}
+                  {
+                    pipelineStatusKey === pipelineStatusValues.NOT_CREATED
+                      || pipelineErrors.includes(pipelineStatusKey)
+                      ? 'Run Data Processing' : 'Save Changes'
+                  }
                 </Button>
               )}
             </Col>


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1028

#### Link to staging deployment URL 

https://ui-agi-ui288.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Use `NotCreated` status to check toggle pipeline buttons.
- "Run Data Processing" button is enabled if the user hasn't run the pipeline.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
