### PR TITLE
[BIOMAGE-1036] - Show data processing after qc is running

### DIFF
--- a/src/components/ContentWrapper.jsx
+++ b/src/components/ContentWrapper.jsx
@@ -209,6 +209,9 @@ const ContentWrapper = (props) => {
     },
   ];
 
+  const waitingForQcToLaunch = gem2sStatusKey === pipelineStatus.SUCCEEDED
+    && pipelineStatusKey === pipelineStatus.NOT_CREATED;
+
   const renderContent = () => {
     if (experimentId) {
       if (
@@ -224,7 +227,7 @@ const ContentWrapper = (props) => {
         return <GEM2SLoadingScreen experimentId={experimentId} gem2sStatus='error' />;
       }
 
-      if (gem2sRunning) {
+      if (gem2sRunning || waitingForQcToLaunch) {
         return <GEM2SLoadingScreen gem2sStatus='running' completedSteps={completedGem2sSteps} />;
       }
 
@@ -257,7 +260,8 @@ const ContentWrapper = (props) => {
   }) => {
     const noExperimentDisable = !experimentId ? disableIfNoExperiment : false;
     const pipelineStatusDisable = disabledByPipelineStatus && (
-      backendError || pipelineRunning || pipelineRunningError
+      backendError || gem2sRunning || gem2sRunningError
+      || waitingForQcToLaunch || pipelineRunning || pipelineRunningError
     );
 
     return (


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1036

#### Link to staging deployment URL 

https://ui-agi-ui295-api134.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

UI - https://github.com/biomage-ltd/ui/pull/295
API - https://github.com/biomage-ltd/api/pull/134

#### Anything else the reviewers should know about the changes here

- Wait for QC status to update to running before showing the pipeline

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
