### PR TITLE
[BIOMAGE-963] - Add species metadata input

### DIFF
--- a/src/__test__/utils/processUpload.test.js
+++ b/src/__test__/utils/processUpload.test.js
@@ -124,7 +124,6 @@ Storage.put = jest.fn().mockImplementation(
 
 describe('processUpload (in development)', () => {
   afterEach(() => {
-    // console.log(fetch.mock.calls);
     mockStorageCalls = [];
     jest.clearAllMocks();
   });

--- a/src/components/data-management/MetadataEditor.jsx
+++ b/src/components/data-management/MetadataEditor.jsx
@@ -18,12 +18,15 @@ const MetadataEditor = (props) => {
 
   const [value, setValue] = useState('');
 
-  const onChange = (e) => setValue(e?.target?.value || e);
+  const onChange = (e) => {
+    setValue(e?.target?.value || e?.value);
+  };
 
   const getContent = () => (
     <Space direction='vertical'>
       {React.cloneElement(children, {
         onChange,
+        value,
       })}
       <Divider style={{ margin: '4px 0' }} />
 
@@ -33,9 +36,7 @@ const MetadataEditor = (props) => {
             <Button
               type='primary'
               size='small'
-              onClick={() => {
-                onReplaceEmpty(value);
-              }}
+              onClick={() => onReplaceEmpty(value)}
             >
               Fill all missing
 

--- a/src/components/data-management/MetadataEditor.jsx
+++ b/src/components/data-management/MetadataEditor.jsx
@@ -19,7 +19,7 @@ const MetadataEditor = (props) => {
   const [value, setValue] = useState('');
 
   const onChange = (e) => {
-    setValue(e?.target?.value || e?.value);
+    setValue(e?.target?.value || e);
   };
 
   const getContent = () => (

--- a/src/components/data-management/MetadataPopover.jsx
+++ b/src/components/data-management/MetadataPopover.jsx
@@ -13,7 +13,6 @@ const MetadataPopover = (props) => {
     onCancel,
     message,
     children,
-    popupContainer,
     ...restOfProps
   } = props;
 

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -348,7 +348,7 @@ const ProjectDetails = ({ width, height }) => {
       const isSpeciesEmpty = (uuid) => metadataKey === 'species' && !samples[uuid].species;
       const isMetadataEmpty = (uuid) => metadataKey !== 'species'
         && (!samples[uuid].metadata[metadataKey]
-          || samples[uuid].metadata[metadataKey] === defaultNA);
+          || samples[uuid].metadata[metadataKey] === DEFAULT_NA);
 
       return isMetadataEmpty(sampleUuid) || isSpeciesEmpty(sampleUuid);
     };
@@ -380,7 +380,7 @@ const ProjectDetails = ({ width, height }) => {
           <MetadataEditor
             onReplaceEmpty={(value) => setCells(value, key, 'REPLACE_EMPTY')}
             onReplaceAll={(value) => setCells(value, key, 'REPLACE_ALL')}
-            onClearAll={() => setCells(defaultNA, key, 'CLEAR_ALL')}
+            onClearAll={() => setCells(DEFAULT_NA, key, 'CLEAR_ALL')}
             massEdit
           >
             <Input />

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -295,7 +295,7 @@ const ProjectDetails = ({ width, height }) => {
       <EditableField
         deleteEnabled
         value={text}
-        onAfterSubmit={(name) => dispatch(updateSample(record.uuid, { name }))}
+        onAfterSubmit={() => dispatch(updateSample(record.uuid, { name }))}
         onDelete={() => dispatch(deleteSamples(record.uuid))}
         validationFunc={(name) => validateInputs(name, validationChecks, validationParams).isValid}
       />
@@ -466,15 +466,11 @@ const ProjectDetails = ({ width, height }) => {
       ),
       fillInBy: <SpeciesSelector data={sortedSpeciesData} />,
       dataIndex: 'species',
-      render: (text, record, rowIdx) => renderEditableFieldCell(
-        defaultNA,
-        text,
-        record,
-        'species',
-        rowIdx,
-        (newValue) => {
-          dispatch(updateSample(record.uuid, { species: newValue }));
-        },
+      render: (text, record) => (
+        <SpeciesSelector
+          data={sortedSpeciesData}
+          onChange={(value) => dispatch(updateSample(record.uuid, { species: value.key }))}
+        />
       ),
       width: 200,
     },

--- a/src/components/data-management/SpeciesSelector.jsx
+++ b/src/components/data-management/SpeciesSelector.jsx
@@ -16,7 +16,7 @@ const SpeciesSelector = (props) => {
 
   return (
     <Select
-      onChange={(value, option) => onChange(option.displayName)}
+      onChange={(value, option) => onChange(value, option)}
       style={{ width: '100%' }}
       dropdownMatchSelectWidth={400}
       labelInValue

--- a/src/components/data-management/SpeciesSelector.jsx
+++ b/src/components/data-management/SpeciesSelector.jsx
@@ -13,31 +13,12 @@ const SpeciesSelector = (props) => {
     return <Skeleton.Input style={{ width: 300 }} size='small' />;
   }
 
-  const createLabel = (scientificName, displayName) => (
-    <Space direction='vertical'>
-      <Text type='primary'>{displayName}</Text>
-      <Text type='secondary'>
-        {scientificName}
-      </Text>
-    </Space>
-  );
-
-  const labeledValue = (organismId) => {
-    const organism = data.find((entry) => entry.id === organismId);
-
-    return {
-      value: organismId,
-      label: !organismId ? <></> : createLabel(organism.scientific_name, organism.display_name),
-    };
-  };
-
   return (
     <Select
-      value={labeledValue(value)}
-      onChange={(selectedValue, option) => onChange(selectedValue, option)}
+      value={value}
+      onChange={(organismId, option) => onChange(organismId, option)}
       style={{ width: '100%' }}
       dropdownMatchSelectWidth={400}
-      labelInValue
       showSearch
       placeholder='Search for common or scientific name...'
       filterOption={(input, option) => option.searchQuery.includes(input.toLowerCase())}
@@ -72,7 +53,14 @@ const SpeciesSelector = (props) => {
           displayName: organism.display_name,
           scientificName: organism.scientific_name,
           searchQuery: `${organism.display_name} ${organism.scientific_name}`.toLowerCase(),
-          label: createLabel(organism.display_name, organism.scientific_name),
+          label: (
+            <Space direction='vertical'>
+              <Text type='primary'>{organism.display_name}</Text>
+              <Text type='secondary'>
+                {organism.scientific_name}
+              </Text>
+            </Space>
+          ),
         }))
       }
     />
@@ -86,7 +74,7 @@ SpeciesSelector.propTypes = {
 };
 
 SpeciesSelector.defaultProps = {
-  value: null,
+  value: '',
   onChange: () => { },
 };
 

--- a/src/components/data-management/SpeciesSelector.jsx
+++ b/src/components/data-management/SpeciesSelector.jsx
@@ -3,20 +3,38 @@ import PropTypes from 'prop-types';
 import {
   Select, Typography, Space, Divider, Skeleton,
 } from 'antd';
-import _ from 'lodash';
 
 const { Text } = Typography;
 
 const SpeciesSelector = (props) => {
-  const { data, onChange } = props;
+  const { data, value, onChange } = props;
 
-  if (!data) {
+  if (!data || data.length === 0) {
     return <Skeleton.Input style={{ width: 300 }} size='small' />;
   }
 
+  const createLabel = (scientificName, displayName) => (
+    <Space direction='vertical'>
+      <Text type='primary'>{displayName}</Text>
+      <Text type='secondary'>
+        {scientificName}
+      </Text>
+    </Space>
+  );
+
+  const labeledValue = (organismId) => {
+    const organism = data.find((entry) => entry.id === organismId);
+
+    return {
+      value: organismId,
+      label: !organismId ? <></> : createLabel(organism.scientific_name, organism.display_name),
+    };
+  };
+
   return (
     <Select
-      onChange={(value, option) => onChange(value, option)}
+      value={labeledValue(value)}
+      onChange={(selectedValue, option) => onChange(selectedValue, option)}
       style={{ width: '100%' }}
       dropdownMatchSelectWidth={400}
       labelInValue
@@ -54,14 +72,7 @@ const SpeciesSelector = (props) => {
           displayName: organism.display_name,
           scientificName: organism.scientific_name,
           searchQuery: `${organism.display_name} ${organism.scientific_name}`.toLowerCase(),
-          label: (
-            <Space direction='vertical'>
-              <Text type='primary'>{organism.display_name}</Text>
-              <Text type='secondary'>
-                {organism.scientific_name}
-              </Text>
-            </Space>
-          ),
+          label: createLabel(organism.display_name, organism.scientific_name),
         }))
       }
     />
@@ -70,10 +81,12 @@ const SpeciesSelector = (props) => {
 
 SpeciesSelector.propTypes = {
   data: PropTypes.array.isRequired,
+  value: PropTypes.string,
   onChange: PropTypes.func,
 };
 
 SpeciesSelector.defaultProps = {
+  value: null,
   onChange: () => { },
 };
 

--- a/src/utils/UploadStatus.js
+++ b/src/utils/UploadStatus.js
@@ -4,7 +4,6 @@ const UploadStatus = {
   COMPRESSING: 'compressing',
   UPLOAD_ERROR: 'uploadError',
   FILE_NOT_FOUND: 'fileNotFound',
-  DATA_MISSING: 'dataMissing',
   FILE_READ_ERROR: 'fileReadError',
   FILE_READ_ABORTED: 'fileReadAborted',
 };
@@ -15,7 +14,6 @@ const message = {
   [UploadStatus.COMPRESSING]: 'Compressing...',
   [UploadStatus.UPLOAD_ERROR]: 'Upload error',
   [UploadStatus.FILE_NOT_FOUND]: 'File not found',
-  [UploadStatus.DATA_MISSING]: 'Data missing',
   [UploadStatus.FILE_READ_ERROR]: 'File read error',
   [UploadStatus.FILE_READ_ABORTED]: 'File read aborted',
 };


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-963

#### Link to staging deployment URL 

https://ui-agi-ui296.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Add dropdown as input to species metadata

# Changes
### Code changes

- Remove `DATA_MISSING` status as it is not used anymore

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
