### PR TITLE
Disable dash metadata track

### DIFF
--- a/src/__test__/utils/metadataUtils.test.js
+++ b/src/__test__/utils/metadataUtils.test.js
@@ -21,12 +21,12 @@ describe('metadataUtils', () => {
 
   it('temporaryMetadataKey creates key correctly', () => {
     const columns = [];
-    expect(temporaryMetadataKey(columns)).toEqual('metadata-0');
+    expect(temporaryMetadataKey(columns)).toEqual('metadata_0');
 
     columns.push(temporaryMetadataKey(columns));
     columns.push('fake-key');
 
-    expect(temporaryMetadataKey(columns)).toEqual('metadata-2');
+    expect(temporaryMetadataKey(columns)).toEqual('metadata_2');
   });
 });
 

--- a/src/__test__/utils/validateInputs.test.js
+++ b/src/__test__/utils/validateInputs.test.js
@@ -82,9 +82,9 @@ describe('validateUnit unit test', () => {
     const invalidName = 'Yumm: A great project!';
     const checks = [rules.ALPHANUM_DASH_SPACE];
 
-    const { isValid: isInvalid, results: invalidResult } = validateInputs(invalidName, checks);
+    const { isValid, results: invalidResult } = validateInputs(invalidName, checks);
 
-    expect(isInvalid).not.toEqual(true);
+    expect(isValid).toEqual(false);
     expect(invalidResult).toEqual([errorMessages.ALPHANUM_DASH_SPACE]);
   });
 
@@ -92,9 +92,9 @@ describe('validateUnit unit test', () => {
     const invalidName = 'Track-1!';
     const checks = [rules.ALPHANUM_SPACE];
 
-    const { isValid: isInvalid, results: invalidResult } = validateInputs(invalidName, checks);
+    const { isValid, results: invalidResult } = validateInputs(invalidName, checks);
 
-    expect(isInvalid).not.toEqual(true);
+    expect(isValid).toEqual(false);
     expect(invalidResult).toEqual([errorMessages.ALPHANUM_SPACE]);
   });
 
@@ -102,9 +102,9 @@ describe('validateUnit unit test', () => {
     const invalidName = '24 Carats';
     const checks = [rules.START_WITH_ALPHABET];
 
-    const { isValid: isInvalid, results: invalidResult } = validateInputs(invalidName, checks);
+    const { isValid, results: invalidResult } = validateInputs(invalidName, checks);
 
-    expect(isInvalid).not.toEqual(true);
+    expect(isValid).toEqual(false);
     expect(invalidResult).toEqual([errorMessages.START_WITH_ALPHABET]);
   });
 

--- a/src/__test__/utils/validateInputs.test.js
+++ b/src/__test__/utils/validateInputs.test.js
@@ -78,7 +78,7 @@ describe('validateUnit unit test', () => {
     expect(invalidResult).toEqual([errorMessages.MIN_2_SEQUENTIAL_CHARS]);
   });
 
-  it('Correctly invalidate names with invalid characters', () => {
+  it('Correctly invalidate names with invalid characters (alphanum, dash, space)', () => {
     const invalidName = 'Yumm: A great project!';
     const checks = [rules.ALPHANUM_DASH_SPACE];
 
@@ -88,7 +88,27 @@ describe('validateUnit unit test', () => {
     expect(invalidResult).toEqual([errorMessages.ALPHANUM_DASH_SPACE]);
   });
 
-  it('Correctly invalidates should not be the same with existing projects', () => {
+  it('Correctly invalidate names with invalid characters (alphanum, space)', () => {
+    const invalidName = 'Track-1!';
+    const checks = [rules.ALPHANUM_SPACE];
+
+    const { isValid: isInvalid, results: invalidResult } = validateInputs(invalidName, checks);
+
+    expect(isInvalid).not.toEqual(true);
+    expect(invalidResult).toEqual([errorMessages.ALPHANUM_SPACE]);
+  });
+
+  it('Correctly invalidate names that does not begin with alphabets', () => {
+    const invalidName = '24 Carats';
+    const checks = [rules.START_WITH_ALPHABET];
+
+    const { isValid: isInvalid, results: invalidResult } = validateInputs(invalidName, checks);
+
+    expect(isInvalid).not.toEqual(true);
+    expect(invalidResult).toEqual([errorMessages.START_WITH_ALPHABET]);
+  });
+
+  it('Correctly invalidates should not be the same with existing values', () => {
     const projectNames = [
       'Project 1',
       'Project 2',

--- a/src/components/data-management/MetadataPopover.jsx
+++ b/src/components/data-management/MetadataPopover.jsx
@@ -10,6 +10,7 @@ const validationChecks = [
   rules.MIN_1_CHAR,
   rules.ALPHANUM_SPACE,
   rules.UNIQUE_NAME_CASE_INSENSITIVE,
+  rules.START_WITH_ALPHABET,
 ];
 
 const MetadataPopover = (props) => {

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -76,7 +76,7 @@ const ProjectDetails = ({ width, height }) => {
   const [canLaunchAnalysis, setCanLaunchAnalysis] = useState(false);
   const [analysisModalVisible, setAnalysisModalVisible] = useState(false);
 
-  const validateMetadataName = [
+  const metadataNameValidation = [
     rules.MIN_1_CHAR,
     rules.ALPHANUM_SPACE,
     rules.START_WITH_ALPHABET,
@@ -357,7 +357,7 @@ const ProjectDetails = ({ width, height }) => {
             )}
             value={name}
             validationFunc={
-              (newName) => validateInputs(newName, validateMetadataName, validationParams).isValid
+              (newName) => validateInputs(newName, metadataNameValidation, validationParams).isValid
             }
           />
           <MetadataEditor

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
-  Table, Typography, Space, Tooltip, PageHeader, Button, Input, Progress, Row, Col,
+  Table, Typography, Space, Tooltip, Button, Input, Progress, Row, Col,
 } from 'antd';
 import { useRouter } from 'next/router';
 import { useSelector, useDispatch } from 'react-redux';
@@ -76,9 +76,10 @@ const ProjectDetails = ({ width, height }) => {
   const [canLaunchAnalysis, setCanLaunchAnalysis] = useState(false);
   const [analysisModalVisible, setAnalysisModalVisible] = useState(false);
 
-  const validationChecks = [
+  const validateMetadataName = [
     rules.MIN_1_CHAR,
-    rules.ALPHANUM_DASH_SPACE,
+    rules.ALPHANUM_SPACE,
+    rules.START_WITH_ALPHABET,
     rules.UNIQUE_NAME_CASE_INSENSITIVE,
   ];
 
@@ -297,7 +298,6 @@ const ProjectDetails = ({ width, height }) => {
         value={text}
         onAfterSubmit={(name) => dispatch(updateSample(record.uuid, { name }))}
         onDelete={() => dispatch(deleteSamples(record.uuid))}
-        validationFunc={(name) => validateInputs(name, validationChecks, validationParams).isValid}
       />
     </Text>
   );
@@ -356,6 +356,9 @@ const ProjectDetails = ({ width, height }) => {
               updateMetadataTrack(name, newName, activeProjectUuid),
             )}
             value={name}
+            validationFunc={
+              (newName) => validateInputs(newName, validateMetadataName, validationParams).isValid
+            }
           />
           <MetadataEditor
             onReplaceEmpty={(value) => {
@@ -611,6 +614,7 @@ const ProjectDetails = ({ width, height }) => {
           pipelineStatus.ABORTED,
           pipelineStatus.TIMED_OUT,
           pipelineStatus.FAILED,
+          pipelineStatus.SUCCEEDED,
         ].includes(backendStatus.gem2s.status)) {
           dispatch(runGem2s(experimentId));
         }

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -614,7 +614,6 @@ const ProjectDetails = ({ width, height }) => {
           pipelineStatus.ABORTED,
           pipelineStatus.TIMED_OUT,
           pipelineStatus.FAILED,
-          pipelineStatus.SUCCEEDED,
         ].includes(backendStatus.gem2s.status)) {
           dispatch(runGem2s(experimentId));
         }

--- a/src/utils/metadataUtils.js
+++ b/src/utils/metadataUtils.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-param-reassign */
-const metadataKeyToName = (key) => key.replace('_', ' ');
+const metadataKeyToName = (key) => key.replace('-', ' ').replace('_', ' ');
 
 const metadataNameToKey = (name) => `${name.trim().replace(/\s+/g, '_')}`;
 
-const temporaryMetadataKey = (columns) => `metadata-${columns.length}`;
+const temporaryMetadataKey = (columns) => `metadata_${columns.length}`;
 
 export {
   metadataKeyToName,

--- a/src/utils/metadataUtils.js
+++ b/src/utils/metadataUtils.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-const metadataKeyToName = (key) => key.replace('-', ' ').replace('_', ' ');
+const metadataKeyToName = (key) => key.replace('_', ' ');
 
 const metadataNameToKey = (name) => `${name.trim().replace(/\s+/g, '_')}`;
 

--- a/src/utils/validateInputs.js
+++ b/src/utils/validateInputs.js
@@ -6,6 +6,7 @@ const rules = {
   ALPHANUM_DASH_SPACE: 'ALPHANUM_DASH_SPACE',
   UNIQUE_NAME: 'UNIQUE_NAME',
   UNIQUE_NAME_CASE_INSENSITIVE: 'UNIQUE_NAME_CASE_INSENSITIVE',
+  START_WITH_ALPHABET: 'START_WITH_ALPHABET',
 };
 
 const errorMessages = {
@@ -16,6 +17,7 @@ const errorMessages = {
   [rules.ALPHANUM_DASH_SPACE]: 'Only letters, numbers, space, _, and - allowed',
   [rules.UNIQUE_NAME]: 'Name is already used',
   [rules.UNIQUE_NAME_CASE_INSENSITIVE]: 'Name is already used',
+  [rules.START_WITH_ALPHABET]: 'Name can only start with letter',
 };
 
 const validationFns = {
@@ -76,6 +78,12 @@ const validationFns = {
 
     if (lowerCaseNames.includes(input.toLowerCase())) return errorMessages[checkName];
 
+    return true;
+  },
+
+  // Start with alphabet - Fail if input starts with non-alphabetic character
+  [rules.START_WITH_ALPHABET](checkName, input) {
+    if (input.match(/^[^a-zA-Z]/gm)) return errorMessages[checkName];
     return true;
   },
 };


### PR DESCRIPTION
# Background
#### Link to issue 

https://this-is-biomage.slack.com/archives/C015CHSUDRU/p1622644162098700

#### Link to staging deployment URL 

https://ui-agi-ui302-api142.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

UI : https://github.com/biomage-ltd/ui/pull/302
API : https://github.com/biomage-ltd/api/pull/142

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

- Add validation when user updates metadata
- Metadata name can not contain dash (`-`) and can not begin with a number.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
