### PR TITLE
Remove new awaits on dispatches

### DIFF
--- a/src/redux/actions/cellSets/updateCellSetsClustering.js
+++ b/src/redux/actions/cellSets/updateCellSetsClustering.js
@@ -49,7 +49,7 @@ const updateCellSetsClustering = (experimentId, resolution) => async (dispatch, 
         data: newCellSets,
       },
     });
-    await dispatch(saveCellSets(experimentId));
+    dispatch(saveCellSets(experimentId));
   } catch (e) {
     dispatch({
       type: CELL_SETS_ERROR,

--- a/src/redux/actions/experiments/createExperiment.js
+++ b/src/redux/actions/experiments/createExperiment.js
@@ -25,7 +25,7 @@ const createExperiment = (
   };
 
   try {
-    await dispatch(saveExperiment(newExperiment.id, newExperiment, false));
+    dispatch(saveExperiment(newExperiment.id, newExperiment, false));
 
     dispatch({
       type: EXPERIMENTS_CREATED,

--- a/src/redux/actions/experiments/updateExperiment.js
+++ b/src/redux/actions/experiments/updateExperiment.js
@@ -10,7 +10,7 @@ const updateExperiment = (
   experiment,
 ) => async (dispatch) => {
   try {
-    await dispatch(saveExperiment(experimentId));
+    dispatch(saveExperiment(experimentId));
 
     dispatch({
       type: EXPERIMENTS_UPDATED,

--- a/src/redux/actions/pipeline/runGem2s.js
+++ b/src/redux/actions/pipeline/runGem2s.js
@@ -38,7 +38,7 @@ const runGem2s = (experimentId) => async (dispatch, getState) => {
       payload: {},
     });
 
-    await dispatch(loadBackendStatus(experimentId));
+    dispatch(loadBackendStatus(experimentId));
 
     dispatch({
       type: EXPERIMENT_SETTINGS_INFO_UPDATE,

--- a/src/redux/actions/pipeline/runPipeline.js
+++ b/src/redux/actions/pipeline/runPipeline.js
@@ -50,7 +50,7 @@ const runPipeline = (experimentId, callerStepKey) => async (dispatch, getState) 
       type: EXPERIMENT_SETTINGS_PIPELINE_START,
       payload: {},
     });
-    await dispatch(loadBackendStatus(experimentId));
+    dispatch(loadBackendStatus(experimentId));
   } catch (e) {
     let { message } = e;
     if (!isServerError(e)) {

--- a/src/redux/actions/samples/createSample.js
+++ b/src/redux/actions/samples/createSample.js
@@ -47,8 +47,8 @@ const createSample = (
   };
 
   try {
-    await dispatch(saveSamples(projectUuid, newSample));
-    await dispatch(saveProject(projectUuid, newProject));
+    dispatch(saveSamples(projectUuid, newSample));
+    dispatch(saveProject(projectUuid, newProject));
 
     dispatch({
       type: SAMPLES_CREATE,

--- a/src/redux/actions/samples/deleteSamples.js
+++ b/src/redux/actions/samples/deleteSamples.js
@@ -60,8 +60,8 @@ const deleteSamples = (
           samples: _.difference(projects[projectUuid].sampels, samplesToDelete),
         };
 
-        await dispatch(saveSamples(projectUuid, newSample, false, false));
-        await dispatch(saveProject(projectUuid, newProject, false));
+        dispatch(saveSamples(projectUuid, newSample, false, false));
+        dispatch(saveProject(projectUuid, newProject, false));
 
         dispatch({
           type: SAMPLES_DELETE,

--- a/src/redux/actions/samples/updateSample.js
+++ b/src/redux/actions/samples/updateSample.js
@@ -23,7 +23,7 @@ const updateSample = (
   const newSample = mergeObjectWithArrays(sample, diff);
 
   try {
-    await dispatch(saveSamples(sample.projectUuid, newSample));
+    dispatch(saveSamples(sample.projectUuid, newSample));
 
     dispatch({
       type: SAMPLES_UPDATE,

--- a/src/redux/actions/samples/updateSampleFile.js
+++ b/src/redux/actions/samples/updateSampleFile.js
@@ -33,7 +33,7 @@ const updateSampleFile = (
       };
 
       const newSample = mergeObjectWithArrays(sample, diffObject);
-      await dispatch(saveSamples(sample.projectUuid, newSample));
+      dispatch(saveSamples(sample.projectUuid, newSample));
     }
 
     dispatch({


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-ui305.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
Awaits introduced in latest commits caused bugs in the redux dispatches in `createSample.js`, in particular when adding multiple samples only one of them remained.

The new awaits introduced in other places were also removed preemptively until we understand how this error was caused.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
