### PR TITLE
building hotfixe & release branches on ci-develop.yaml

### DIFF
--- a/.github/workflows/ci-develop.yaml
+++ b/.github/workflows/ci-develop.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - develop
+      - release/**
+      - hotfix/**
   pull_request:
     branches:
       - develop

--- a/.github/workflows/draft-new-release.yaml
+++ b/.github/workflows/draft-new-release.yaml
@@ -1,0 +1,54 @@
+name: Create a new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version you want to release.'
+        required: true
+
+jobs:
+  create-release:
+    name: ${{ format('Create release {0}', github.event.inputs.repo) }}
+    runs-on: ubuntu-20.04
+    steps:
+
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token
+          fetch-depth: 0
+
+      - id: create-release
+        name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - id: initialize-git-info
+        name: Initialize mandatory git info
+        run: git config user.name "Github Actions"
+
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ format('release/{0}', github.event.inputs.version ) }}
+
+      - id: create-pr
+        name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: master
+          title: Release version ${{ github.event.inputs.version }}
+          body: |
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+
+            This release candidate should be staged in :
+            https://ui-${{ github.event.inputs.version }}.scp-staging.biomage.net/
+
+            Merging this PR will create a GitHub release, update master & develop branches, and upload any assets that are created as part of the release build.


### PR DESCRIPTION
Building hotfix & release branches on ci-develop.yaml because it's easier than building them as master PRs.