### PR TITLE
using also k8s env when retrieving identity pool

### DIFF
--- a/src/utils/ssr/getAuthenticationInfo.js
+++ b/src/utils/ssr/getAuthenticationInfo.js
@@ -59,7 +59,7 @@ const getAuthenticationInfo = async () => {
   const k8sEnv = process.env.K8S_ENV || 'staging';
 
   const identityPoolId = IdentityPools.find(
-    (pool) => pool.IdentityPoolName.includes(sandboxId),
+    (pool) => pool.IdentityPoolName.includes(`${k8sEnv}-${sandboxId}`),
   ).IdentityPoolId;
 
   const userPoolId = UserPools.find((pool) => pool.Name.includes(k8sEnv)).Id;


### PR DESCRIPTION
The signin redirect loop was caused by not including the k8s env to filter the identity pools