### PR TITLE
[BIOMAGE-1118] - Fix normalization option

### DIFF
--- a/src/__test__/redux/reducers/__snapshots__/experimentSettingsReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/experimentSettingsReducer.test.js.snap
@@ -150,15 +150,15 @@ Object {
         "method": "seuratv4",
         "methodSettings": Object {
           "fastmnn": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "seuratv4": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "unisample": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
         },
@@ -270,15 +270,15 @@ Object {
         "method": "seuratv4",
         "methodSettings": Object {
           "fastmnn": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "seuratv4": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "unisample": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
         },
@@ -397,15 +397,15 @@ Object {
         "method": "seuratv4",
         "methodSettings": Object {
           "fastmnn": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "seuratv4": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "unisample": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
         },
@@ -516,15 +516,15 @@ Object {
         "method": "seuratv4",
         "methodSettings": Object {
           "fastmnn": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "seuratv4": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
           "unisample": Object {
-            "normalization": "logNormalize",
+            "normalisation": "logNormalize",
             "numGenes": 2000,
           },
         },

--- a/src/__test__/test-utils/experimentSettings.mock.js
+++ b/src/__test__/test-utils/experimentSettings.mock.js
@@ -59,15 +59,15 @@ const testableProcessingConfig = {
       methodSettings: {
         seuratv4: {
           numGenes: 2000,
-          normalization: 'logNormalize',
+          normalisation: 'logNormalize',
         },
         fastmnn: {
           numGenes: 2000,
-          normalization: 'logNormalize',
+          normalisation: 'logNormalize',
         },
         unisample: {
           numGenes: 2000,
-          normalization: 'logNormalize',
+          normalisation: 'logNormalize',
         },
       },
     },

--- a/src/components/data-processing/DataIntegration/NormalisationOptions.jsx
+++ b/src/components/data-processing/DataIntegration/NormalisationOptions.jsx
@@ -110,7 +110,9 @@ const NormalisationOptions = (props) => {
           disabled={disabled}
         >
           <Option value='logNormalize'>LogNormalize</Option>
-          <Option value='scTransform'>SCTransform</Option>
+
+          {/* scTransform is disabled until implemented in the QC pipeline */}
+          <Option disabled value='scTransform'>SCTransform</Option>
         </Select>
 
       </Form.Item>

--- a/src/components/data-processing/DataIntegration/NormalisationOptions.jsx
+++ b/src/components/data-processing/DataIntegration/NormalisationOptions.jsx
@@ -99,11 +99,11 @@ const NormalisationOptions = (props) => {
       )}
       >
         <Select
-          value={config.normalization}
+          value={config.normalisation}
           onChange={(val) => onUpdate({
             dataIntegration: {
               methodSettings: {
-                [methodId]: { normalization: val },
+                [methodId]: { normalisation: val },
               },
             },
           })}


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1118

#### Link to staging deployment URL 

https://ui-agi-ui339.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- `normalisation` is the term used throughout the backend, while `normalization` is used in the UI. This PR fixes this so that `normalisation` is used in the UI
- `scTransform` is not yet implemented in the backend. To prevent users from using it, I disable it.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
