### PR TITLE
fix quibles

### DIFF
--- a/src/components/data-processing/DataIntegration/CalculationConfig.jsx
+++ b/src/components/data-processing/DataIntegration/CalculationConfig.jsx
@@ -207,7 +207,7 @@ const CalculationConfig = (props) => {
                   { dimensionalityReduction: { excludeGeneCategories: val } },
                 )}
                 value={dimensionalityReduction.excludeGeneCategories}
-                disabled={disabled}
+                disabled={true}
               >
                 <Space direction='vertical'>
                   <Checkbox value='ribosomal'>ribosomal</Checkbox>

--- a/src/components/data-processing/DataIntegration/NormalisationOptions.jsx
+++ b/src/components/data-processing/DataIntegration/NormalisationOptions.jsx
@@ -20,7 +20,7 @@ const NormalisationOptions = (props) => {
 
   return (
     <>
-      <Form.Item label='# of HGV genes'>
+      <Form.Item label='# of HVGs'>
         <InputNumber
           value={numGenes}
           step={100}
@@ -53,8 +53,8 @@ const NormalisationOptions = (props) => {
         {' '}
         <Tooltip overlay={(
           <span>
-            Number of genes to mark as top highly variable genes (HGV).
-            Integration as well as PCA is based on a sensible selection of HGV.
+            Number of genes to mark as top highly variable genes (HVGs).
+            Integration as well as PCA is based on a sensible selection of HVGs.
             Here, this number selects the top variable genes based on the "vst" method.
             The default 2000 has been found to be a sensible for many cases.
             Further info can be found

--- a/src/components/data-processing/GenesVsUMIs/CalculationConfig.jsx
+++ b/src/components/data-processing/GenesVsUMIs/CalculationConfig.jsx
@@ -16,9 +16,6 @@ const GenesVsUMIsConfig = (props) => {
 
   return (
     <>
-      <Form.Item
-        label='Regression type:'
-      />
       <Form.Item label='p-level cut-off:'>
         <Space direction='horizontal'>
           <Tooltip title='Linear regression (Gam) of UMIs vs features (genes) is performed for all cells in order to detect outliers. The ‘p-level cut-off’ is the stringency for defining outliers: ‘p.level’ refers to the confidence level for a given cell to deviate from the main trend. The smaller the number the more stringent cut-off.


### PR DESCRIPTION
# Background
These are some UI quibles that me and Vicky identified:

1) Gene categories to exclude are not currently used so I disabled them:

![image](https://user-images.githubusercontent.com/15719520/122261709-81e45b80-ce89-11eb-888a-55db32810e3c.png)

2) Highly variable genes was using the acronym HGVs instead of HVGs:

![image](https://user-images.githubusercontent.com/15719520/122261837-a3ddde00-ce89-11eb-8a83-e0583273fe82.png)

3) There was a **Regression type:** label without any input which I removed:

![image](https://user-images.githubusercontent.com/15719520/122262008-cd970500-ce89-11eb-860f-274a7e8efde2.png)


# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
