### PR TITLE
[Data Processing UX] Allow user to change settings of multiple filters without running QC pipeline

### DIFF
--- a/src/__test__/components/data-processing/configure-embedding/CalculationConfig.test.jsx
+++ b/src/__test__/components/data-processing/configure-embedding/CalculationConfig.test.jsx
@@ -166,7 +166,7 @@ describe('Data Processing CalculationConfig', () => {
           experimentId='1234'
           width={50}
           height={50}
-          changedFilters={{ current: new Set(['filter1', 'awesomeFilter']) }}
+          changedFilters={{ current: new Set() }}
           onPipelineRun={onPipelineRun}
         />
       </Provider>,

--- a/src/__test__/components/data-processing/configure-embedding/CalculationConfig.test.jsx
+++ b/src/__test__/components/data-processing/configure-embedding/CalculationConfig.test.jsx
@@ -74,6 +74,7 @@ describe('Data Processing CalculationConfig', () => {
     const component = mount(
       <Provider store={store}>
         <CalculationConfig
+          changedFilters={jest.fn()}
           experimentId='1234'
           width={50}
           height={50}

--- a/src/__test__/components/data-processing/configure-embedding/CalculationConfig.test.jsx
+++ b/src/__test__/components/data-processing/configure-embedding/CalculationConfig.test.jsx
@@ -38,7 +38,7 @@ describe('Data Processing CalculationConfig', () => {
     },
   };
 
-  const onPipelineRun = () => { };
+  const onPipelineRun = () => {};
 
   configure({ adapter: new Adapter() });
 
@@ -74,7 +74,7 @@ describe('Data Processing CalculationConfig', () => {
     const component = mount(
       <Provider store={store}>
         <CalculationConfig
-          changedFilters={jest.fn()}
+          changedFilters={{ current: new Set() }}
           experimentId='1234'
           width={50}
           height={50}
@@ -98,6 +98,7 @@ describe('Data Processing CalculationConfig', () => {
           experimentId='1234'
           width={50}
           height={50}
+          changedFilters={{ current: new Set() }}
           onPipelineRun={onPipelineRun}
         />
       </Provider>,
@@ -121,6 +122,7 @@ describe('Data Processing CalculationConfig', () => {
           experimentId='1234'
           width={50}
           height={50}
+          changedFilters={{ current: new Set() }}
           onPipelineRun={onPipelineRun}
         />
       </Provider>,
@@ -164,6 +166,7 @@ describe('Data Processing CalculationConfig', () => {
           experimentId='1234'
           width={50}
           height={50}
+          changedFilters={{ current: new Set(['filter1', 'awesomeFilter']) }}
           onPipelineRun={onPipelineRun}
         />
       </Provider>,
@@ -182,5 +185,51 @@ describe('Data Processing CalculationConfig', () => {
     await waitForActions(store, [EXPERIMENT_SETTINGS_PROCESSING_UPDATE, EMBEDDINGS_LOADING]);
     expect(store.getActions().length).toEqual(2);
     expect(store.getActions()).toMatchSnapshot();
+  });
+
+  it('Clicking run with other filters changed triggers the pipeline', async () => {
+    const store = mockStore(storeState);
+    const mockOnPipelineRun = jest.fn();
+    const component = mount(
+      <Provider store={store}>
+        <CalculationConfig
+          experimentId='1234'
+          width={50}
+          height={50}
+          changedFilters={{ current: new Set(['filter1', 'awesomeFilter']) }}
+          onPipelineRun={mockOnPipelineRun}
+        />
+      </Provider>,
+    );
+    act(() => { component.find(Select).at(0).getElement().props.onChange('tsne'); });
+    component.update();
+
+    const runButton = component.find(Button);
+    runButton.simulate('click');
+    expect(mockOnPipelineRun).toBeCalledTimes(1);
+  });
+
+  it("Clicking run with NO other filters changed doesn't trigger the pipeline", async () => {
+    const store = mockStore(storeState);
+    const mockOnPipelineRun = jest.fn();
+    const component = mount(
+      <Provider store={store}>
+        <CalculationConfig
+          experimentId='1234'
+          width={50}
+          height={50}
+          changedFilters={{ current: new Set() }}
+          onPipelineRun={mockOnPipelineRun}
+        />
+      </Provider>,
+    );
+    act(() => { component.find(Select).at(0).getElement().props.onChange('tsne'); });
+    component.update();
+
+    const runButton = component.find(Button);
+    runButton.simulate('click', {});
+    expect(mockOnPipelineRun).toBeCalledTimes(0);
+    await waitForActions(store, [EXPERIMENT_SETTINGS_PROCESSING_UPDATE, EMBEDDINGS_LOADING]);
+    expect(store.getActions()[1].type).toEqual(EMBEDDINGS_LOADING);
   });
 });

--- a/src/__test__/components/data-processing/data-integration/CalculationConfig.test.jsx
+++ b/src/__test__/components/data-processing/data-integration/CalculationConfig.test.jsx
@@ -80,7 +80,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} changedFilters={jest.fn()} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={{ current: new Set() }} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 
@@ -95,7 +95,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={{ current: new Set() }} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 
@@ -113,7 +113,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={{ current: new Set() }} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 
@@ -128,7 +128,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={{ current: new Set() }} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 
@@ -146,7 +146,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={{ current: new Set() }} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 
@@ -159,7 +159,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={{ current: new Set() }} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 
@@ -184,7 +184,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={{ current: new Set() }} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 

--- a/src/__test__/components/data-processing/data-integration/CalculationConfig.test.jsx
+++ b/src/__test__/components/data-processing/data-integration/CalculationConfig.test.jsx
@@ -80,7 +80,7 @@ describe('Data Integration Calculation Config', () => {
 
     const component = mount(
       <Provider store={store}>
-        <CalculationConfig experimentId={experimentId} config={config} onPipelineRun={onPipelineRun} />
+        <CalculationConfig experimentId={experimentId} changedFilters={jest.fn()} config={config} onPipelineRun={onPipelineRun} />
       </Provider>,
     );
 

--- a/src/components/data-processing/Classifier/Classifier.jsx
+++ b/src/components/data-processing/Classifier/Classifier.jsx
@@ -30,7 +30,6 @@ const Classifier = (props) => {
 
   const plotUuid = generateDataProcessingPlotUuid(sampleId, filterName, 0);
   const plotType = 'classifierEmptyDropsPlot';
-
   const allowedPlotActions = {
     export: true,
     compiled: false,

--- a/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
@@ -37,7 +37,6 @@ const EMBEDD_METHOD_TEXT = 'Reducing the dimensionality does lose some informati
 const CalculationConfig = (props) => {
   const { experimentId, onPipelineRun, changedFilters } = props;
   const FILTER_UUID = 'configureEmbedding';
-
   const dispatch = useDispatch();
 
   const [changesOutstanding, setChangesOutstanding] = useState(false);
@@ -117,11 +116,12 @@ const CalculationConfig = (props) => {
   const runWithCurrentEmbeddingSettings = () => {
     updateSettings(changes);
     setChangesOutstanding(false);
-    dispatch(loadEmbedding(experimentId, embeddingMethod, true));
     if (changedFilters?.current.size) {
       // other steps are changed so we run the pipeline
       changedFilters.current.add(FILTER_UUID);
       onPipelineRun();
+    } else {
+      dispatch(loadEmbedding(experimentId, embeddingMethod, true));
     }
   };
   const newChanges = changes;
@@ -309,7 +309,6 @@ const CalculationConfig = (props) => {
           >
             <Select
               value={changes.embeddingSettings.method}
-              // changes.({ embeddingSettings: { method: value } })
               onChange={(value) => {
                 newChanges.embeddingSettings.method = value;
                 setChanges({ ...newChanges });
@@ -431,7 +430,7 @@ const CalculationConfig = (props) => {
 CalculationConfig.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
-  changedFilters: PropTypes.isRequired,
+  changedFilters: PropTypes.object.isRequired,
 };
 
 export default CalculationConfig;

--- a/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
@@ -81,13 +81,6 @@ const CalculationConfig = (props) => {
   }, [louvainSettings]);
 
   useEffect(() => {
-    // adding the filter to the changed ones so its run when the pipeline is triggered
-    if (!_.isEqual(changes, initialValues) && !changedFilters.current.has(FILTER_UUID)) {
-      changedFilters.current.add(FILTER_UUID);
-    }
-  }, [changes]);
-
-  useEffect(() => {
     if (!minDistance && umapSettings) {
       setMinDistance(umapSettings.minimumDistance);
     }
@@ -125,6 +118,11 @@ const CalculationConfig = (props) => {
     updateSettings(changes);
     setChangesOutstanding(false);
     dispatch(loadEmbedding(experimentId, embeddingMethod, true));
+    if (changedFilters.current.size) {
+      // other steps are changed so we run the pipeline
+      changedFilters.current.add(FILTER_UUID);
+      onPipelineRun();
+    }
   };
   const newChanges = changes;
 

--- a/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
@@ -94,7 +94,7 @@ const CalculationConfig = (props) => {
     if (diff.embeddingSettings) {
       // If this is an embedding change, indicate to user that their changes are not
       // applied until they hit Run.
-      changedFilters.add(FILTER_UUID);
+      changedFilters?.current.add(FILTER_UUID);
       setChangesOutstanding(true);
       dispatch(updateProcessingSettings(
         experimentId,

--- a/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
@@ -118,7 +118,7 @@ const CalculationConfig = (props) => {
     updateSettings(changes);
     setChangesOutstanding(false);
     dispatch(loadEmbedding(experimentId, embeddingMethod, true));
-    if (changedFilters.current.size) {
+    if (changedFilters?.current.size) {
       // other steps are changed so we run the pipeline
       changedFilters.current.add(FILTER_UUID);
       onPipelineRun();

--- a/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
@@ -35,7 +35,7 @@ const EMBEDD_METHOD_TEXT = 'Reducing the dimensionality does lose some informati
   + 't-SNE and UMAP are stochastic and very much dependent on choice of parameters (t-SNE even more than UMAP) and can yield very different results in different runs. ';
 
 const CalculationConfig = (props) => {
-  const { experimentId, onPipelineRun } = props;
+  const { experimentId, onPipelineRun, changedFilters } = props;
   const FILTER_UUID = 'configureEmbedding';
 
   const dispatch = useDispatch();
@@ -94,7 +94,7 @@ const CalculationConfig = (props) => {
     if (diff.embeddingSettings) {
       // If this is an embedding change, indicate to user that their changes are not
       // applied until they hit Run.
-
+      changedFilters.add(FILTER_UUID);
       setChangesOutstanding(true);
       dispatch(updateProcessingSettings(
         experimentId,
@@ -427,6 +427,7 @@ const CalculationConfig = (props) => {
 CalculationConfig.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
+  changedFilters: PropTypes.isRequired,
 };
 
 export default CalculationConfig;

--- a/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/CalculationConfig.jsx
@@ -81,6 +81,13 @@ const CalculationConfig = (props) => {
   }, [louvainSettings]);
 
   useEffect(() => {
+    // adding the filter to the changed ones so its run when the pipeline is triggered
+    if (!_.isEqual(changes, initialValues) && !changedFilters.current.has(FILTER_UUID)) {
+      changedFilters.current.add(FILTER_UUID);
+    }
+  }, [changes]);
+
+  useEffect(() => {
     if (!minDistance && umapSettings) {
       setMinDistance(umapSettings.minimumDistance);
     }
@@ -94,7 +101,6 @@ const CalculationConfig = (props) => {
     if (diff.embeddingSettings) {
       // If this is an embedding change, indicate to user that their changes are not
       // applied until they hit Run.
-      changedFilters?.current.add(FILTER_UUID);
       setChangesOutstanding(true);
       dispatch(updateProcessingSettings(
         experimentId,

--- a/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
@@ -29,7 +29,7 @@ import Loader from '../../Loader';
 const { Panel } = Collapse;
 
 const ConfigureEmbedding = (props) => {
-  const { experimentId, onPipelineRun } = props;
+  const { experimentId, onPipelineRun, changedFilters } = props;
   const [plot, setPlot] = useState(null);
   const cellSets = useSelector((state) => state.cellSets);
   const cellMeta = useSelector((state) => state.cellMeta);
@@ -397,7 +397,7 @@ const ConfigureEmbedding = (props) => {
         </Col>
 
         <Col flex='1 0px'>
-          <CalculationConfig experimentId={experimentId} onPipelineRun={onPipelineRun} />
+          <CalculationConfig experimentId={experimentId} onPipelineRun={onPipelineRun} changedFilters={changedFilters} />
           <Collapse>
             <Panel header='Plot styling' key='styling'>
               <div style={{ height: 8 }} />
@@ -417,6 +417,7 @@ const ConfigureEmbedding = (props) => {
 ConfigureEmbedding.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
+  changedFilters: PropTypes.isRequired,
 };
 
 export default ConfigureEmbedding;

--- a/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
@@ -417,7 +417,7 @@ const ConfigureEmbedding = (props) => {
 ConfigureEmbedding.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
-  changedFilters: PropTypes.isRequired,
+  changedFilters: PropTypes.object.isRequired,
 };
 
 export default ConfigureEmbedding;

--- a/src/components/data-processing/DataIntegration/CalculationConfig.jsx
+++ b/src/components/data-processing/DataIntegration/CalculationConfig.jsx
@@ -88,7 +88,7 @@ const CalculationConfig = (props) => {
   const [changesOutstanding, setChangesOutstanding] = useState(false);
 
   const updateSettings = (diff) => {
-    changedFilters.current.add(FILTER_UUID);
+    changedFilters?.current.add(FILTER_UUID);
     setChangesOutstanding(true);
     dispatch(updateProcessingSettings(
       experimentId,

--- a/src/components/data-processing/DataIntegration/CalculationConfig.jsx
+++ b/src/components/data-processing/DataIntegration/CalculationConfig.jsx
@@ -288,7 +288,7 @@ CalculationConfig.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
-  changedFilters: PropTypes.isRequired,
+  changedFilters: PropTypes.object.isRequired,
   disableDataIntegration: PropTypes.bool,
 };
 

--- a/src/components/data-processing/DataIntegration/CalculationConfig.jsx
+++ b/src/components/data-processing/DataIntegration/CalculationConfig.jsx
@@ -34,7 +34,7 @@ const { Panel } = Collapse;
 
 const CalculationConfig = (props) => {
   const {
-    experimentId, onPipelineRun, disabled, disableDataIntegration,
+    experimentId, onPipelineRun, disabled, disableDataIntegration, changedFilters,
   } = props;
   const FILTER_UUID = 'dataIntegration';
 
@@ -88,6 +88,7 @@ const CalculationConfig = (props) => {
   const [changesOutstanding, setChangesOutstanding] = useState(false);
 
   const updateSettings = (diff) => {
+    changedFilters.current.add(FILTER_UUID);
     setChangesOutstanding(true);
     dispatch(updateProcessingSettings(
       experimentId,
@@ -119,7 +120,7 @@ const CalculationConfig = (props) => {
           {changesOutstanding && (
             <Form.Item>
               <Alert
-                message='Your changes are not yet applied. To rerun data integration, click Apply.'
+                message='Your changes are not yet applied. To rerun data integration, click Run.'
                 type='warning'
                 showIcon
               />
@@ -207,7 +208,7 @@ const CalculationConfig = (props) => {
                   { dimensionalityReduction: { excludeGeneCategories: val } },
                 )}
                 value={dimensionalityReduction.excludeGeneCategories}
-                disabled={true}
+                disabled
               >
                 <Space direction='vertical'>
                   <Checkbox value='ribosomal'>ribosomal</Checkbox>
@@ -287,6 +288,7 @@ CalculationConfig.propTypes = {
   experimentId: PropTypes.string.isRequired,
   onPipelineRun: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  changedFilters: PropTypes.isRequired,
   disableDataIntegration: PropTypes.bool,
 };
 

--- a/src/components/data-processing/DataIntegration/DataIntegration.jsx
+++ b/src/components/data-processing/DataIntegration/DataIntegration.jsx
@@ -378,7 +378,7 @@ DataIntegration.propTypes = {
   onPipelineRun: PropTypes.func.isRequired,
   experimentId: PropTypes.string.isRequired,
   stepDisabled: PropTypes.bool,
-  changedFilters: PropTypes.isRequired,
+  changedFilters: PropTypes.object.isRequired,
   disableDataIntegration: PropTypes.bool,
 };
 

--- a/src/components/data-processing/DataIntegration/DataIntegration.jsx
+++ b/src/components/data-processing/DataIntegration/DataIntegration.jsx
@@ -29,7 +29,7 @@ import generateDataProcessingPlotUuid from '../../../utils/generateDataProcessin
 const { Panel } = Collapse;
 const DataIntegration = (props) => {
   const {
-    experimentId, onPipelineRun, stepDisabled, disableDataIntegration,
+    experimentId, onPipelineRun, stepDisabled, disableDataIntegration, changedFilters,
   } = props;
   const [selectedPlot, setSelectedPlot] = useState('embedding');
   const [plot, setPlot] = useState(null);
@@ -355,6 +355,7 @@ const DataIntegration = (props) => {
             config={calculationConfig}
             onPipelineRun={onPipelineRun}
             disabled={stepDisabled}
+            changedFilters={changedFilters}
             disableDataIntegration={disableDataIntegration}
           />
           <Collapse>
@@ -377,6 +378,7 @@ DataIntegration.propTypes = {
   onPipelineRun: PropTypes.func.isRequired,
   experimentId: PropTypes.string.isRequired,
   stepDisabled: PropTypes.bool,
+  changedFilters: PropTypes.isRequired,
   disableDataIntegration: PropTypes.bool,
 };
 

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -304,7 +304,8 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
         <DataIntegration
           experimentId={expId}
           key={key}
-          onPipelineRun={() => onPipelineRun(key)}
+          changedFilters={changedFilters}
+          onPipelineRun={() => onPipelineRun(Array.from(changedFilters.current))}
           disableDataIntegration={sampleKeys && sampleKeys.length === 1}
         />
       ),
@@ -318,7 +319,8 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
         <ConfigureEmbedding
           experimentId={expId}
           key={key}
-          onPipelineRun={() => onPipelineRun(key)}
+          changedFilters={changedFilters}
+          onPipelineRun={() => onPipelineRun(Array.from(changedFilters.current))}
         />
       ),
     },

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -76,6 +76,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   const [preFilteredSamples, setPreFilteredSamples] = useState([])
   const [stepDisabledByCondition, setStepDisabledByCondition] = useState(false)
   const carouselRef = useRef(null);
+  const changedFilters = useRef(new Set())
 
   const disableStepsOnCondition = {
     prefilter: ['classifier'],
@@ -169,7 +170,8 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
     return stepAppearances.length > 0;
   }
 
-  const onConfigChange = () => {
+  const onConfigChange = (key) => {
+    changedFilters.current.add(key)
     setChangesOutstanding(true);
   };
 
@@ -195,7 +197,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               key={key}
               sampleId={sample.key}
               sampleIds={sampleKeys}
-              onConfigChange={onConfigChange}
+              onConfigChange={()=>onConfigChange(key)}
               stepDisabled={!processingConfig[key]?.enabled}
             />
           )}
@@ -218,7 +220,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               key={key}
               sampleId={sample.key}
               sampleIds={sampleKeys}
-              onConfigChange={onConfigChange}
+              onConfigChange={()=>onConfigChange(key)}
               stepDisabled={!processingConfig[key].enabled}
             />
           )}
@@ -241,7 +243,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               key={key}
               sampleId={sample.key}
               sampleIds={sampleKeys}
-              onConfigChange={onConfigChange}
+              onConfigChange={()=>onConfigChange(key)}
               stepDisabled={!processingConfig[key].enabled}
             />
           )}
@@ -264,7 +266,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               key={key}
               sampleId={sample.key}
               sampleIds={sampleKeys}
-              onConfigChange={onConfigChange}
+              onConfigChange={()=>onConfigChange(key)}
               stepDisabled={!processingConfig[key].enabled}
             />
           )}
@@ -287,7 +289,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               key={key}
               sampleId={sample.key}
               sampleIds={sampleKeys}
-              onConfigChange={onConfigChange}
+              onConfigChange={()=>onConfigChange(key)}
               stepDisabled={!processingConfig[key].enabled}
             />
           )}
@@ -329,23 +331,17 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   }, [stepIdx, carouselRef.current]);
 
   const changeStepId = (newStepIdx) => {
-    if (changesOutstanding) {
-      upcomingStepIdxRef.current = newStepIdx;
-
-      setShowChangesWillBeLost(true);
-    } else {
       setStepIdx(newStepIdx);
-    }
   }
 
   // Called when the pipeline is triggered to be run by the user.
   const onPipelineRun = (stepKey) => {
     setChangesOutstanding(false);
-    dispatch((runPipeline(experimentId, stepKey)))
+    dispatch((runPipeline(experimentId, Array.from(changedFilters.current))))
   }
 
   const ignoreLostChanges = () => {
-    setShowChangesWillBeLost(false)
+    // setShowChangesWillBeLost(false)
     setChangesOutstanding(false);
     setStepIdx(upcomingStepIdxRef.current);
   }
@@ -362,21 +358,6 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
   const renderTitle = () => (
     <>
-      <Modal
-        visible={showChangesWillBeLost}
-        onOk={ignoreLostChanges}
-        onCancel={() => setShowChangesWillBeLost(false)}
-        okText='Leave this page'
-        cancelText='Stay on this page'
-        title='Unsaved changes'
-      >
-        <Space style={{ margin: '15px' }}>
-          <p>
-            You have unsaved settings changes. If you leave the page, these changes
-            will be lost.
-          </p>
-        </Space>
-      </Modal>
       <Row style={{ display: 'flex' }}>
         <Col style={{ flex: 1, display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
           <Row style={{ display: 'flex' }} gutter={16}>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -70,7 +70,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   const cellSets = useSelector((state) => state.cellSets);
 
   const [changesOutstanding, setChangesOutstanding] = useState(false);
-  const [showChangesWillBeLost, setShowChangesWillBeLost] = useState(false);
+
   const [stepIdx, setStepIdx] = useState(0);
   const [applicableFilters, setApplicableFilters] = useState([])
   const [preFilteredSamples, setPreFilteredSamples] = useState([])
@@ -335,15 +335,11 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   }
 
   // Called when the pipeline is triggered to be run by the user.
-  const onPipelineRun = (stepKey) => {
+  const onPipelineRun = (steps) => {
     setChangesOutstanding(false);
-    dispatch((runPipeline(experimentId, Array.from(changedFilters.current))))
-  }
+    changedFilters.current = new Set();
+    dispatch((runPipeline(experimentId, steps)))
 
-  const ignoreLostChanges = () => {
-    // setShowChangesWillBeLost(false)
-    setChangesOutstanding(false);
-    setStepIdx(upcomingStepIdxRef.current);
   }
 
   const renderWithInnerScroll = (innerRenderer) => {
@@ -473,7 +469,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                   id='runFilterButton'
                   data-testid='runFilterButton'
                   type='primary'
-                  onClick={() => { onPipelineRun(steps[stepIdx].key) }}
+                  onClick={() => { onPipelineRun(changedFilters.current.size ? Array.from(changedFilters.current) : steps[stepIdx].key) }}
                   disabled={!pipelineErrors.includes(pipelineStatusKey) && !changesOutstanding}
                 >
                   {pipelineErrors.includes(pipelineStatusKey) ? 'Run Data Processing' : 'Save changes'}

--- a/src/redux/actions/pipeline/runPipeline.js
+++ b/src/redux/actions/pipeline/runPipeline.js
@@ -21,7 +21,6 @@ const runPipeline = (experimentId, callerStepKeys) => async (dispatch, getState)
     // eslint-disable-next-line no-param-reassign
     callerStepKeys = [callerStepKeys];
   }
-
   const processingConfig = callerStepKeys.map((key) => {
     const currentConfig = getState().experimentSettings.processing[key];
     return {
@@ -51,7 +50,6 @@ const runPipeline = (experimentId, callerStepKeys) => async (dispatch, getState)
     );
     const json = await response.json();
     throwIfRequestFailed(response, json, endUserMessages.ERROR_STARTING_PIPLELINE);
-
     dispatch({
       type: EXPERIMENT_SETTINGS_PIPELINE_START,
       payload: {},

--- a/src/redux/actions/pipeline/runPipeline.js
+++ b/src/redux/actions/pipeline/runPipeline.js
@@ -8,7 +8,7 @@ import {
 } from '../../actionTypes/experimentSettings';
 import loadBackendStatus from '../experimentSettings/loadBackendStatus';
 
-const runPipeline = (experimentId, callerStepKey) => async (dispatch, getState) => {
+const runPipeline = (experimentId, callerStepKeys) => async (dispatch, getState) => {
   dispatch({
     type: EXPERIMENT_SETTINGS_BACKEND_STATUS_LOADING,
     payload: {
@@ -16,7 +16,13 @@ const runPipeline = (experimentId, callerStepKey) => async (dispatch, getState) 
     },
   });
 
-  const processingConfig = getState().experimentSettings.processing[callerStepKey];
+  const processingConfig = callerStepKeys.map((key) => {
+    const currentConfig = getState().experimentSettings.processing[key];
+    return {
+      name: key,
+      body: currentConfig,
+    };
+  });
 
   const url = `/v1/experiments/${experimentId}/pipelines`;
   try {
@@ -34,12 +40,7 @@ const runPipeline = (experimentId, callerStepKey) => async (dispatch, getState) 
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          processingConfig: [
-            {
-              name: callerStepKey,
-              body: processingConfig,
-            },
-          ],
+          processingConfig,
         }),
       },
     );

--- a/src/redux/actions/pipeline/runPipeline.js
+++ b/src/redux/actions/pipeline/runPipeline.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import fetchAPI from '../../../utils/fetchAPI';
 import { isServerError, throwIfRequestFailed } from '../../../utils/fetchErrors';
 import endUserMessages from '../../../utils/endUserMessages';
@@ -15,6 +16,11 @@ const runPipeline = (experimentId, callerStepKeys) => async (dispatch, getState)
       experimentId,
     },
   });
+
+  if (!_.isArray(callerStepKeys)) {
+    // eslint-disable-next-line no-param-reassign
+    callerStepKeys = [callerStepKeys];
+  }
 
   const processingConfig = callerStepKeys.map((key) => {
     const currentConfig = getState().experimentSettings.processing[key];

--- a/src/redux/actions/pipeline/runPipeline.js
+++ b/src/redux/actions/pipeline/runPipeline.js
@@ -29,7 +29,6 @@ const runPipeline = (experimentId, callerStepKeys) => async (dispatch, getState)
       body: currentConfig,
     };
   });
-
   const url = `/v1/experiments/${experimentId}/pipelines`;
   try {
     // We are only sending the configuration that we know changed


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-1122
#### Link to staging deployment URL 
https://ui-grasp6-ui345.scp-staging.biomage.net/
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
![image](https://user-images.githubusercontent.com/22479584/122765101-d2ecb900-d2a8-11eb-83ae-a6179629a102.png)

