### PR TITLE
[BIOMAGE-1105] Tweak Data Processing step dropdown

### DIFF
--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -442,7 +442,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                               >
                                 <EllipsisOutlined />
                               </Text>
-                              <span style={{ marginLeft: '0.25rem' }}>{`${i + 1}. C ${name}`}</span>
+                              <span style={{ marginLeft: '0.25rem' }}>{text}</span>
                             </>
                           ) : pipelineNotFinished && !pipelineRunning && !isStepComplete(key) ? (
                             <>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -393,6 +393,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                   steps.map(
                     ({ name, key }, i) => {
                       const disabledByPipeline = (pipelineNotFinished && !isStepComplete(key));
+                      const text = `${i + 1}. ${name}`;
 
                       return (
                         <Option
@@ -404,6 +405,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                         >
                           {processingConfig[key]?.enabled === false ? (
                             <>
+                              {/* disabled */}
                               <Text
                                 type='secondary'
 
@@ -413,11 +415,12 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                               <span
                                 style={{ marginLeft: '0.25rem', textDecoration: 'line-through' }}
                               >
-                                {name}
+                                {text}
                               </span>
                             </>
                           ) : !disabledByPipeline ? (
                             <>
+                              {/* finished */}
                               <Text
                                 type='success'
 
@@ -427,28 +430,30 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                               <span
                                 style={{ marginLeft: '0.25rem' }}
                               >
-                                {name}
+                                {text}
                               </span>
                             </>
                           ) : pipelineRunning && !isStepComplete(key) ? (
                             <>
+                              {/* incomplete */}
                               <Text
                                 type='warning'
                                 strong
                               >
                                 <EllipsisOutlined />
                               </Text>
-                              <span style={{ marginLeft: '0.25rem' }}>{name}</span>
+                              <span style={{ marginLeft: '0.25rem' }}>{`${i + 1}. C ${name}`}</span>
                             </>
                           ) : pipelineNotFinished && !pipelineRunning && !isStepComplete(key) ? (
                             <>
+                              {/* failed */}
                               <Text
                                 type='danger'
                                 strong
                               >
                                 <WarningOutlined />
                               </Text>
-                              <span style={{ marginLeft: '0.25rem' }}>{name}</span>
+                              <span style={{ marginLeft: '0.25rem' }}>{text}</span>
                             </>
                           ) : <></>}
                         </Option>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -386,7 +386,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                 onChange={(idx) => {
                   changeStepId(idx);
                 }}
-                style={{ fontWeight: 'bold' }}
+                style={{ fontWeight: 'bold', width: 270 }}
                 placeholder='Jump to a step...'
               >
                 {


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1105
#### Link to staging deployment URL 
https://ui-james-ui346.scp-staging.biomage.net/
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
I tried for a long time to find a way to fix the `Select` to the width of the longest option, but couldn't, so settled on hardcoding it. If there is reasonable way to do this just let me know!

![image](https://user-images.githubusercontent.com/68030850/122793091-b35a8e00-d2b2-11eb-8d53-a5c6c719d97d.png)


# Changes
### Code changes
- Set `Select` width to width of longest option
- Added numbers to options
- Added comment describing when each option variant is used

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
