### PR TITLE
Removing Louvain clusters in the Group by menu of the heatmap settings breaks the platform

### DIFF
--- a/src/components/plots/helpers/populateHeatmapData.js
+++ b/src/components/plots/helpers/populateHeatmapData.js
@@ -112,13 +112,12 @@ const populateHeatmapData = (cellSets, config, expression, selectedGenes, downsa
 
     return intersectedCellSets;
   };
-  const getAllEnabledCellIds = (groupByRootNodes) => {
-    // const cellIdsInAnyGroupBy = getAllCellsSet(groupByRootNodes);
-
+  const getAllEnabledCellIds = () => {
     // we want to avoid displaying elements which are not in a louvain cluster
     // so initially consider as enabled only cells in louvain clusters
     // See: https://biomage.atlassian.net/browse/BIOMAGE-809
-    const louvainClusters = groupByRootNodes.find((groupingName) => groupingName.key === 'louvain');
+    const louvainClusters = hierarchy.find((clusters) => clusters.key === 'louvain');
+
     const cellIsInLouvainCluster = getCellsSetInGroup(louvainClusters);
 
     // Remove cells from groups marked as hidden by the user in the UI.
@@ -130,7 +129,7 @@ const populateHeatmapData = (cellSets, config, expression, selectedGenes, downsa
   };
   const splitByCartesianProductIntersections = (groupByRootNodes) => {
     // Beginning with only one set of all the cells that we want to see
-    let buckets = [getAllEnabledCellIds(groupByRootNodes)];
+    let buckets = [getAllEnabledCellIds()];
 
     // Perform successive cartesian product intersections across each groupby
     groupByRootNodes.forEach((currentRootNode) => {


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-959
#### Link to staging deployment URL 
https://ui-stefan-ui347.scp-staging.biomage.net/experiments/stefan-ui347-1510c2708eed4c09f697532a0564f22d/data-processing
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
