### PR TITLE
Fix dropdown width

### DIFF
--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -381,12 +381,13 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
         <Col style={{ flex: 1, display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
           <Row style={{ display: 'flex' }} gutter={16}>
             <Col>
+              {/* Should be just wide enough that no ellipsis appears */}
               <Select
                 value={stepIdx}
                 onChange={(idx) => {
                   changeStepId(idx);
                 }}
-                style={{ fontWeight: 'bold', width: 270 }}
+                style={{ fontWeight: 'bold', width: 290 }}
                 placeholder='Jump to a step...'
               >
                 {


### PR DESCRIPTION
This is a quick followup to #346 - I missed that the dropdown is not quite wide enough and shows an ellipsis when the longest option is selected.

Before:
![image](https://user-images.githubusercontent.com/68030850/122928242-9335d800-d361-11eb-8fd2-c4035018de43.png)

After:
![image](https://user-images.githubusercontent.com/68030850/122928419-c37d7680-d361-11eb-94a7-b895c967cb67.png)
