### PR TITLE
fix doublet score filter coloring

### DIFF
--- a/src/utils/plotSpecs/generateDoubletScoreHistogram.js
+++ b/src/utils/plotSpecs/generateDoubletScoreHistogram.js
@@ -1,6 +1,6 @@
 const generateSpec = (config, plotData) => {
   let legend = null;
-  const generateStatus = `(datum.bin1 <= ${config.probabilityThreshold}) ? 'high score' : 'low score'`;
+  const generateStatus = `(datum.bin1 <= ${config.probabilityThreshold}) ? 'low score' : 'high score'`;
 
   legend = !config.legend.enabled ? {} : [
     {
@@ -98,11 +98,8 @@ const generateSpec = (config, plotData) => {
       {
         name: 'color',
         type: 'ordinal',
-        range:
-          [
-            'green', 'blue',
-          ],
-        domain: ['high score', 'low score'],
+        range: ['green', 'blue'],
+        domain: ['low score', 'high score'],
       },
     ],
     axes: [


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-961

#### Link to staging deployment URL 

https://ui-agi-ui354.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

- Fix confusing doublet score legend. Now : 
cell with doublet score < probability threshold = `low score`, green
cell with doublet score > probability threshold = `high score`, blue

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
