### PR TITLE
[BIOMAGE-638] Do not re-sort clusters in categorical embedding

### DIFF
--- a/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
+++ b/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
@@ -41,7 +41,6 @@ const generateSpec = (config, plotData) => {
   }
   return {
     $schema: 'https://vega.github.io/schema/vega/v5.json',
-    description: 'A basic scatter plot example depicting automobile statistics.',
     width: config?.dimensions.width,
     height: config?.dimensions.height,
     autosize: 'fit',
@@ -84,7 +83,7 @@ const generateSpec = (config, plotData) => {
         name: 'cellSetColors',
         type: 'ordinal',
         range: { data: 'values', field: colorFieldName },
-        domain: { data: 'values', field: 'cluster', sort: true },
+        domain: { data: 'values', field: 'cluster' },
       },
       {
         name: 'sampleToName',


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-638
#### Link to staging deployment URL 
https://ui-james-ui356.scp-staging.biomage.net/
#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/worker/pull/143

#### Anything else the reviewers should know about the changes here
Oh man, this was annoying to figure out. The above PR makes the worker send clusters in naturally sorted order. The categorical embedding was the only one on the UI that still showed the wrong order. I eventually tracked it down to this `sort: true` which causes Vega to re-sort the clusters incorrectly.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
