### PR TITLE
[BIOMAGE-938] Improve UI responsiveness by eliminating unnecessary renders

### DIFF
--- a/src/components/data-exploration/embedding/Embedding.jsx
+++ b/src/components/data-exploration/embedding/Embedding.jsx
@@ -71,7 +71,7 @@ const Embedding = (props) => {
     if (!embeddingSettings) {
       dispatch(loadProcessingSettings(experimentId));
     }
-  }, [experimentId]);
+  }, []);
 
   // Then, try to load the embedding with the appropriate data.
   useEffect(() => {

--- a/src/components/data-processing/CellSizeDistribution/CellSizeDistribution.jsx
+++ b/src/components/data-processing/CellSizeDistribution/CellSizeDistribution.jsx
@@ -116,7 +116,7 @@ const CellSizeDistribution = (props) => {
         dispatch(loadPlotConfig(experimentId, obj.plotUuid, obj.plotType));
       }
     });
-  }, [experimentId]);
+  }, []);
 
   useEffect(() => {
     if (config && plotData && expConfig) {

--- a/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
@@ -54,7 +54,7 @@ const ConfigureEmbedding = (props) => {
         dispatch(loadCellMeta(experimentId, dataName));
       }
     });
-  }, [experimentId]);
+  }, []);
 
   const plots = {
     cellCluster: {
@@ -264,7 +264,7 @@ const ConfigureEmbedding = (props) => {
         dispatch(loadPlotConfig(experimentId, obj.plotUuid, obj.plotType));
       }
     });
-  }, [experimentId]);
+  }, []);
 
   useEffect(() => {
     // if we change a plot and the config is not saved yet

--- a/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
@@ -56,7 +56,7 @@ const ConfigureEmbedding = (props) => {
     });
   }, []);
 
-  const [plots] = useState({
+  const plots = {
     cellCluster: {
       title: 'Colored by CellSets',
       plotUuid: generateDataProcessingPlotUuid(null, filterName, 0),
@@ -123,7 +123,7 @@ const ConfigureEmbedding = (props) => {
         />
       ),
     },
-  });
+  };
 
   const plotSpecificStylingControl = {
     sample: [

--- a/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
@@ -56,7 +56,7 @@ const ConfigureEmbedding = (props) => {
     });
   }, []);
 
-  const plots = {
+  const [plots] = useState({
     cellCluster: {
       title: 'Colored by CellSets',
       plotUuid: generateDataProcessingPlotUuid(null, filterName, 0),
@@ -123,7 +123,7 @@ const ConfigureEmbedding = (props) => {
         />
       ),
     },
-  };
+  });
 
   const plotSpecificStylingControl = {
     sample: [

--- a/src/components/data-processing/DataIntegration/DataIntegration.jsx
+++ b/src/components/data-processing/DataIntegration/DataIntegration.jsx
@@ -218,7 +218,7 @@ const DataIntegration = (props) => {
         dispatch(loadPlotConfig(experimentId, obj.plotUuid, obj.plotType));
       }
     });
-  }, [experimentId]);
+  }, []);
 
   useEffect(() => {
     // if we change a plot and the config is not saved yet

--- a/src/components/data-processing/DataIntegration/DataIntegration.jsx
+++ b/src/components/data-processing/DataIntegration/DataIntegration.jsx
@@ -44,7 +44,7 @@ const DataIntegration = (props) => {
     _.debounce((plotUuid) => dispatch(savePlotConfig(experimentId, plotUuid)), 2000), [],
   );
 
-  const plots = {
+  const [plots] = useState({
     embedding: {
       title: 'Sample embedding',
       plotUuid: generateDataProcessingPlotUuid(null, configureEmbeddingFilterName, 1),
@@ -94,7 +94,7 @@ const DataIntegration = (props) => {
       ),
       blockedByConfigureEmbedding: false,
     },
-  };
+  });
 
   const plotSpecificStylingControl = {
     embedding: [

--- a/src/components/data-processing/DoubletScores/DoubletScores.jsx
+++ b/src/components/data-processing/DoubletScores/DoubletScores.jsx
@@ -57,6 +57,9 @@ const DoubletScores = (props) => {
   const [renderConfig, setRenderConfig] = useState(null);
 
   useEffect(() => {
+  }, []);
+
+  useEffect(() => {
     const newConfig = _.clone(config);
     _.merge(newConfig, expConfig);
 
@@ -67,7 +70,7 @@ const DoubletScores = (props) => {
     if (!config) {
       dispatch(loadPlotConfig(experimentId, plotUuid, plotType));
     }
-  }, [experimentId]);
+  }, []);
 
   const plotStylingControlsConfig = [
     {

--- a/src/components/data-processing/DoubletScores/DoubletScores.jsx
+++ b/src/components/data-processing/DoubletScores/DoubletScores.jsx
@@ -57,9 +57,6 @@ const DoubletScores = (props) => {
   const [renderConfig, setRenderConfig] = useState(null);
 
   useEffect(() => {
-  }, []);
-
-  useEffect(() => {
     const newConfig = _.clone(config);
     _.merge(newConfig, expConfig);
 

--- a/src/components/data-processing/MitochondrialContent/MitochondrialContent.jsx
+++ b/src/components/data-processing/MitochondrialContent/MitochondrialContent.jsx
@@ -97,7 +97,7 @@ const MitochondrialContent = (props) => {
         dispatch(loadPlotConfig(experimentId, obj.plotUuid, obj.plotType));
       }
     });
-  }, [experimentId]);
+  }, []);
 
   useEffect(() => {
     if (config && plotData && expConfig) {

--- a/src/components/plots/FrequencyPlot.jsx
+++ b/src/components/plots/FrequencyPlot.jsx
@@ -24,7 +24,7 @@ const FrequencyPlot = (props) => {
     if (!hierarchy && !properties) {
       dispatch(loadCellSets(experimentId));
     }
-  }, [experimentId]);
+  }, []);
 
   const spec = generateSpec(config, generateData(hierarchy, properties, config));
 

--- a/src/components/plots/FrequencyPlot.jsx
+++ b/src/components/plots/FrequencyPlot.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Vega } from 'react-vega';
 import PropTypes from 'prop-types';
@@ -15,6 +15,7 @@ const FrequencyPlot = (props) => {
   const dispatch = useDispatch();
 
   const cellSets = useSelector((state) => state.cellSets);
+  const [plotSpec, setPlotSpec] = useState({});
 
   const {
     hierarchy, properties,
@@ -26,11 +27,15 @@ const FrequencyPlot = (props) => {
     }
   }, []);
 
-  const spec = generateSpec(config, generateData(hierarchy, properties, config));
+  useEffect(() => {
+    if (hierarchy && properties) {
+      setPlotSpec(generateSpec(config, generateData(hierarchy, properties, config)));
+    }
+  }, [hierarchy, properties]);
 
   return (
     <center>
-      <Vega spec={spec} renderer='canvas' actions={actions} />
+      <Vega spec={plotSpec} renderer='canvas' actions={actions} />
     </center>
   );
 };

--- a/src/components/plots/MiniPlot.jsx
+++ b/src/components/plots/MiniPlot.jsx
@@ -51,7 +51,6 @@ const MiniPlot = (props) => {
   );
 
   const renderPlot = () => {
-    // Spinner for main window
     if (!config) {
       return (
         <center>
@@ -75,4 +74,4 @@ MiniPlot.propTypes = {
   actions: PropTypes.bool.isRequired,
 };
 
-export default MiniPlot;
+export default React.memo(MiniPlot);

--- a/src/pages/experiments/[experimentId]/plots-and-tables/embedding-categorical/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/embedding-categorical/index.jsx
@@ -42,7 +42,7 @@ const EmbeddingCategoricalIndex = ({ experimentId }) => {
     // try to load the plot configuration.
     dispatch(loadCellSets(experimentId));
     dispatch(loadPlotConfig(experimentId, plotUuid, plotType));
-  }, [experimentId]);
+  }, []);
 
   const generateCellSetOptions = () => {
     if (cellSets.loading) {

--- a/src/pages/experiments/[experimentId]/plots-and-tables/embedding-continuous/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/embedding-continuous/index.jsx
@@ -36,7 +36,7 @@ const EmbeddingContinuousIndex = ({ experimentId }) => {
   useEffect(() => {
     dispatch(loadPlotConfig(experimentId, plotUuid, plotType));
     dispatch(loadCellSets(experimentId));
-  }, [experimentId]);
+  }, []);
 
   const geneExpression = useSelector((state) => state.genes.expression);
   const fetching = useSelector((state) => state.genes.properties.views[plotUuid]?.fetching);

--- a/src/pages/experiments/[experimentId]/plots-and-tables/frequency/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/frequency/index.jsx
@@ -47,7 +47,7 @@ const frequencyPlot = ({ experimentId }) => {
   useEffect(() => {
     dispatch(loadCellSets(experimentId));
     dispatch(loadPlotConfig(experimentId, plotUuid, plotType));
-  }, [experimentId]);
+  }, []);
 
   const getCellOptions = (type) => {
     const filteredOptions = hierarchy.filter((element) => (

--- a/src/pages/experiments/[experimentId]/plots-and-tables/heatmap/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/heatmap/index.jsx
@@ -42,7 +42,7 @@ const HeatmapPlot = ({ experimentId }) => {
   useEffect(() => {
     dispatch(loadPlotConfig(experimentId, plotUuid, plotType));
     dispatch(loadCellSets(experimentId));
-  }, [experimentId]);
+  }, []);
   useEffect(() => {
     if (!config || _.isEmpty(expressionData)) {
       return;

--- a/src/pages/experiments/[experimentId]/plots-and-tables/violin/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/violin/index.jsx
@@ -46,7 +46,7 @@ const ViolinIndex = ({ experimentId }) => {
   useEffect(() => {
     dispatch(loadPlotConfig(experimentId, plotUuid, plotType));
     dispatch(loadCellSets(experimentId));
-  }, [experimentId]);
+  }, []);
 
   // updateField is a subset of what default config has and contains only the things we want change
   const updatePlotWithChanges = (updateField) => {
@@ -125,7 +125,7 @@ const ViolinIndex = ({ experimentId }) => {
       <Panel header='Data Transformation' key='16'>
         {config ? (
           <div>
-            { false // Control removed until we are able to get the raw values
+            {false // Control removed until we are able to get the raw values
               && (
                 <Form.Item>
                   <p>Transform Gene Expression</p>

--- a/src/pages/experiments/[experimentId]/plots-and-tables/volcano/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/volcano/index.jsx
@@ -56,7 +56,7 @@ const VolcanoPlot = ({ experimentId }) => {
 
   useEffect(() => {
     dispatch(loadPlotConfig(experimentId, plotUuid, plotType));
-  }, [experimentId]);
+  }, []);
 
   useEffect(() => {
     // Sync plot and settings with last used config


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-938

#### Link to staging deployment URL 
https://ui-marcellp-ui359.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here

In addition, some components relied on `experimentId` in their `useEffect` hooks. As `experimentId` is now a prop that is automatically assigned to all pages it is unnecessary and causes two calls instead of one (one on initial render, one when `experimentId` changes, i.e. immediately after). This is now eliminated in cases where `experimentId` was the only dependency to a `useEffect` hook.

# Changes
### Code changes
Deleted the carousel component as we did not use it for anything and it was terrible for both layout and performance. UI feels much faster now.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR
![image](https://user-images.githubusercontent.com/16019444/123263743-3701be00-d4f1-11eb-9f39-ed2454146a43.png)
