### PR TITLE
[BIOMAGE-1166] - Change skeleton image to loading

### DIFF
--- a/src/components/plots/ViolinPlot.jsx
+++ b/src/components/plots/ViolinPlot.jsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Vega } from 'react-vega';
 
-import { Skeleton } from 'antd';
+import Loader from '../Loader';
 import PlatformError from '../PlatformError';
 import { generateSpec, generateData } from '../../utils/plotSpecs/generateViolinSpec';
 import { loadGeneExpression, loadPaginatedGeneProperties } from '../../redux/actions/genes';
@@ -117,7 +117,7 @@ const ViolinPlot = (props) => {
       || highestDispersionLoading) {
       return (
         <center>
-          <Skeleton.Image style={{ width: 400, height: 400 }} />
+          <Loader />
         </center>
       );
     }


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1166

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Change image in violin plot to loader to show if the plot is loading.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
