### PR TITLE
[BIOMAGE-1189] added matomo tracking

### DIFF
--- a/assets/self-styles.less
+++ b/assets/self-styles.less
@@ -1,1 +1,2 @@
+@import "~antd/dist/antd.less";
 @import "./antd-custom.less";

--- a/package-lock.json
+++ b/package-lock.json
@@ -8715,6 +8715,11 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
     },
+    "@socialgouv/matomo-next": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@socialgouv/matomo-next/-/matomo-next-1.2.2.tgz",
+      "integrity": "sha512-VWIToHeF0rFtLlGGkjdfUCtLckZebwXwYlnAVYwqMivUboqRgxl7wsUGkGfp6HM4cfYla9NQw4mbqRPXfTGu5Q=="
+    },
     "@testing-library/dom": {
       "version": "7.30.2",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.2.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@blueprintjs/core": "^3.45.0",
     "@blueprintjs/icons": "^3.26.1",
     "@next/bundle-analyzer": "^10.0.9",
+    "@socialgouv/matomo-next": "^1.2.2",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-less": "^1.0.1",
     "antd": "^4.16.5",

--- a/src/components/UserButton.jsx
+++ b/src/components/UserButton.jsx
@@ -38,11 +38,7 @@ const UserButton = () => {
       }
     });
 
-    getUser().then((userData) => {
-      setUser(userData);
-      // set the user email as tracking ID
-      // setTrackingId(userData.attributes.email);
-    });
+    getUser().then((userData) => setUser(userData));
   }, []);
 
   const content = () => (

--- a/src/components/UserButton.jsx
+++ b/src/components/UserButton.jsx
@@ -8,6 +8,7 @@ import {
 import Link from 'next/link';
 import { Auth, Hub } from 'aws-amplify';
 import endUserMessages from '../utils/endUserMessages';
+import { resetTrackingId } from '../utils/tracking';
 import pushNotificationMessage from '../utils/pushNotificationMessage';
 
 const UserButton = () => {
@@ -25,6 +26,7 @@ const UserButton = () => {
           getUser().then((userData) => setUser(userData));
           break;
         case 'signOut':
+          resetTrackingId();
           setUser(null);
           break;
         case 'signIn_failure':
@@ -36,7 +38,11 @@ const UserButton = () => {
       }
     });
 
-    getUser().then((userData) => setUser(userData));
+    getUser().then((userData) => {
+      setUser(userData);
+      // set the user email as tracking ID
+      // setTrackingId(userData.attributes.email);
+    });
   }, []);
 
   const content = () => (

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -21,6 +21,7 @@ import AnalysisModal from './AnalysisModal';
 import UploadDetailsModal from './UploadDetailsModal';
 import MetadataPopover from './MetadataPopover';
 
+import { trackAnalysisLaunched } from '../../utils/tracking';
 import { getFromUrlExpectOK } from '../../utils/getDataExpectOK';
 import {
   deleteSamples, updateSample,
@@ -569,6 +570,7 @@ const ProjectDetails = ({ width, height }) => {
   };
 
   const launchAnalysis = async (experimentId) => {
+    trackAnalysisLaunched();
     await dispatch(runGem2s(experimentId));
     router.push(analysisPath.replace('[experimentId]', experimentId));
   };

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -9,6 +9,7 @@ import Amplify, { Storage, withSSRContext } from 'aws-amplify';
 import _ from 'lodash';
 import AWS from 'aws-sdk';
 import { Credentials } from '@aws-amplify/core';
+import { initTracking } from '../utils/tracking';
 import ContentWrapper from '../components/ContentWrapper';
 import NotFoundPage from './404';
 import UnauthorizedPage from './401';
@@ -16,6 +17,8 @@ import Error from './_error';
 import { wrapper } from '../redux/store';
 import '../../assets/self-styles.less';
 import '../../assets/nprogress.css';
+import { ssrGetCurrentEnvironment } from '../utils/environment';
+
 import CustomError from '../utils/customError';
 
 const mockCredentialsForInframock = () => {
@@ -61,6 +64,10 @@ const WrappedApp = ({ Component, pageProps }) => {
   const [amplifyConfigured, setAmplifyConfigured] = useState(!amplifyConfig);
 
   const environment = useSelector((state) => state.networkResources.environment);
+
+  useEffect(() => {
+    initTracking(environment);
+  }, []);
 
   useEffect(() => {
     if (amplifyConfig) {
@@ -183,6 +190,7 @@ WrappedApp.getInitialProps = async ({ Component, ctx }) => {
   try {
     const { Auth } = withSSRContext(ctx);
     Auth.configure(results.amplifyConfig.Auth);
+
     if (query?.experimentId) {
       const { default: getExperimentInfo } = require('../utils/ssr/getExperimentInfo');
       const experimentInfo = await getExperimentInfo(ctx, store, Auth);

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -13,7 +13,7 @@ const trackingInfo = {
     siteId: 1,
   },
   [Env.STAGING]: {
-    enabled: true,
+    enabled: true, // TODO disable for staging before merging
     siteId: 2,
   },
   [Env.DEVELOPMENT]: {
@@ -31,7 +31,6 @@ const initTracking = async (environment) => {
   env = environment;
   const { siteId, enabled } = getTrackingDetails(env);
   if (enabled === false) {
-    console.log(`tracking init disabled in env ${env}`);
     return;
   }
 
@@ -39,16 +38,14 @@ const initTracking = async (environment) => {
   // first set the user ID and then initialize the tracking so it correctly tracks first page.
   push(['setUserId', user.attributes.email]);
   init({ url: MATOMO_URL, siteId });
-
-  console.log(`initialized tracking to ${siteId} for ${env}`);
 };
 
 const resetTrackingId = () => {
   const { enabled } = getTrackingDetails(env);
   if (enabled === false) {
-    console.log(`setting tracking ID disabled in env ${env}`);
     return;
   }
+
   push(['resetUserId']);
   // we also force a new visit to be created for the pageviews after logout
   push(['appendToTrackingUrl', 'new_visit=1']);
@@ -57,10 +54,8 @@ const resetTrackingId = () => {
 const trackAnalysisLaunched = () => {
   const { enabled } = getTrackingDetails(env);
   if (enabled === false) {
-    console.log(`tracking analysis launched disabled in env ${env}`);
     return;
   }
-  console.log(`tracking analysis launched in ${env}`);
   push(['trackEvent', 'data-management', 'launch-analysis']);
 };
 

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -6,6 +6,7 @@ const MATOMO_URL = 'https://biomage.matomo.cloud/';
 
 // To test a staging deployment, you'll need to go to biomage.matomo.cloud
 // and change the URL there to point to your staging env URL.
+// To test locally, just enable the development environemnt.
 // The Site Ids are defined in biomage.matomo.cloud
 const trackingInfo = {
   [Env.PRODUCTION]: {
@@ -13,11 +14,11 @@ const trackingInfo = {
     siteId: 1,
   },
   [Env.STAGING]: {
-    enabled: true, // TODO disable for staging before merging
+    enabled: false,
     siteId: 2,
   },
   [Env.DEVELOPMENT]: {
-    enabled: true,
+    enabled: false,
     siteId: 3,
   },
 };
@@ -40,6 +41,7 @@ const initTracking = async (environment) => {
   init({ url: MATOMO_URL, siteId });
 };
 
+// reset the user ID when loggging out
 const resetTrackingId = () => {
   const { enabled } = getTrackingDetails(env);
   if (enabled === false) {
@@ -50,12 +52,19 @@ const resetTrackingId = () => {
   // we also force a new visit to be created for the pageviews after logout
   push(['appendToTrackingUrl', 'new_visit=1']);
 };
-// the push method takes as parameter t
+
 const trackAnalysisLaunched = () => {
   const { enabled } = getTrackingDetails(env);
   if (enabled === false) {
     return;
   }
+  // Matomo events consist of four primary components which need to be configured,
+  // only two of which are required:
+  // * Category(Required) , and Form Events.
+  // * Action(Required)
+  // * Name(Optional – Recommended)
+  // * Value(Optional)
+  // See https://matomo.org/docs/event-tracking/ for more info
   push(['trackEvent', 'data-management', 'launch-analysis']);
 };
 

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -1,0 +1,69 @@
+import { init, push } from '@socialgouv/matomo-next';
+import { Auth } from 'aws-amplify';
+import Env from './environment';
+
+const MATOMO_URL = 'https://biomage.matomo.cloud/';
+
+// To test a staging deployment, you'll need to go to biomage.matomo.cloud
+// and change the URL there to point to your staging env URL.
+// The Site Ids are defined in biomage.matomo.cloud
+const trackingInfo = {
+  [Env.PRODUCTION]: {
+    enabled: true,
+    siteId: 1,
+  },
+  [Env.STAGING]: {
+    enabled: true,
+    siteId: 2,
+  },
+  [Env.DEVELOPMENT]: {
+    enabled: true,
+    siteId: 3,
+  },
+};
+
+let env = Env.DEVELOPMENT;
+
+const getTrackingDetails = (e) => trackingInfo[e];
+
+const initTracking = async (environment) => {
+  // set the environment for the tracking sytem
+  env = environment;
+  const { siteId, enabled } = getTrackingDetails(env);
+  if (enabled === false) {
+    console.log(`tracking init disabled in env ${env}`);
+    return;
+  }
+
+  const user = await Auth.currentAuthenticatedUser();
+  // first set the user ID and then initialize the tracking so it correctly tracks first page.
+  push(['setUserId', user.attributes.email]);
+  init({ url: MATOMO_URL, siteId });
+
+  console.log(`initialized tracking to ${siteId} for ${env}`);
+};
+
+const resetTrackingId = () => {
+  const { enabled } = getTrackingDetails(env);
+  if (enabled === false) {
+    console.log(`setting tracking ID disabled in env ${env}`);
+    return;
+  }
+  push(['resetUserId']);
+  // we also force a new visit to be created for the pageviews after logout
+  push(['appendToTrackingUrl', 'new_visit=1']);
+};
+// the push method takes as parameter t
+const trackAnalysisLaunched = () => {
+  const { enabled } = getTrackingDetails(env);
+  if (enabled === false) {
+    console.log(`tracking analysis launched disabled in env ${env}`);
+    return;
+  }
+  console.log(`tracking analysis launched in ${env}`);
+  push(['trackEvent', 'data-management', 'launch-analysis']);
+};
+
+export {
+  initTracking, resetTrackingId, trackAnalysisLaunched,
+};


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1189

#### Link to staging deployment URL 

https://ui-matomo-tracking.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

You can run this PR locally or staging and see the events in biomage.matomo.cloud 
Ask Pol / Agi for the log in account.

# Changes
### Code changes

Added a nextjs tracker which handles all links implicitly. In addition I added a custom event to track when a user clicks the laun experiment button.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR

![image](https://user-images.githubusercontent.com/2961095/125287620-71ef5880-e31d-11eb-9dc3-52207cea694f.png)
