### PR TITLE
Use switch for x-axis rotation setting

### DIFF
--- a/src/components/plots/styling/AxesDesign.jsx
+++ b/src/components/plots/styling/AxesDesign.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Slider, Form, Input, Radio,
+  Slider, Form, Input, Radio, Switch,
 } from 'antd';
 import useUpdateThrottled from '../../../utils/customHooks/useUpdateThrottled';
 
@@ -47,15 +47,13 @@ const AxesDesign = (props) => {
       </Form.Item>
 
       <Form.Item label='Rotate X-Axis Labels'>
-        <Radio.Group
-          value={newConfig.axes.xAxisRotateLabels}
-          onChange={(event) => {
-              handleChange({ axes: { xAxisRotateLabels: event.target.value } })
+        <Switch
+          checked={newConfig.axes.xAxisRotateLabels}
+          onChange={(checked) => {
+              handleChange({ axes: { xAxisRotateLabels: checked } })
             }}
           >
-          <Radio value={true}>On</Radio>
-          <Radio value={false}>Off</Radio>
-        </Radio.Group>
+        </Switch>
       </Form.Item>
 
       <Form.Item label='Axes Label Size'>


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this
#372
#### Anything else the reviewers should know about the changes here
A while after implementing the above PR I realised that a radio group with the options "On" and "Off" should really be a binary checkbox or switch. It annoyed me.
# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
