### PR TITLE
[BIOMAGE-1199]UI crashes when closing tiles in Data Exploration

### DIFF
--- a/src/pages/experiments/[experimentId]/data-exploration/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-exploration/index.jsx
@@ -188,10 +188,10 @@ const ExplorationViewPage = ({
                 <MosaicWindow
                   path={path}
                   title={id}
-                  toolbarControls={TILE_MAP[id].toolbarControls}
+                  toolbarControls={TILE_MAP[id]?.toolbarControls}
                   key={id}
                 >
-                  {renderWindow(TILE_MAP[id].component, width, height)}
+                  {renderWindow(TILE_MAP[id]?.component, width, height)}
                 </MosaicWindow>
               )}
             </ReactResizeDetector>


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-1199
#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
