### PR TITLE
[BIOMAGE-1207] - Fix QC navigation

### DIFF
--- a/.github/workflows/ci-develop.yaml
+++ b/.github/workflows/ci-develop.yaml
@@ -181,9 +181,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - id: install-yq
-        name: Install yq for modifying the eksctl yaml spec.
+        name: Install yq for modifying the deployment spec.
         run: |-
-          sudo wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+          sudo wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
 
       - id: fill-metadata
         name: Fill out a new HelmRelease resource

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,9 +172,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - id: install-yq
-        name: Install yq for modifying the eksctl yaml spec.
+        name: Install yq for modifying the deployment spec.
         run: |-
-          sudo wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+          sudo wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
 
       - id: fill-metadata
         name: Fill out a new HelmRelease resource

--- a/src/__test__/components/data-processing/CalculationConfigContainer.test.jsx
+++ b/src/__test__/components/data-processing/CalculationConfigContainer.test.jsx
@@ -111,4 +111,22 @@ describe('CalculationConfigContainer', () => {
     state = store.getState().experimentSettings.processing;
     expect(state[filterName][sampleIds[0]]).toEqual(state[filterName][sampleIds[1]]);
   });
+  it('updates the redux store for all samples when auto is applied to one sample and then copied to all', () => {
+    let state = store.getState().experimentSettings.processing;
+
+    // Apply manual settings to first sample and copy to all samples
+    setRadioButton('manual');
+    userEvent.click(screen.getByText('Copy to all samples'));
+    state = store.getState().experimentSettings.processing;
+    expect(state[filterName][sampleIds[0]].auto).toEqual(false);
+    expect(state[filterName][sampleIds[1]].auto).toEqual(false);
+
+    // Apply automatic settings to first sample and copy to all samples
+    // The other samples should also have auto set to automatic.
+    setRadioButton('automatic');
+    userEvent.click(screen.getByText('Copy to all samples'));
+    state = store.getState().experimentSettings.processing;
+    expect(state[filterName][sampleIds[0]].auto).toEqual(true);
+    expect(state[filterName][sampleIds[1]].auto).toEqual(true);
+  });
 });

--- a/src/components/data-processing/StatusIndicator.jsx
+++ b/src/components/data-processing/StatusIndicator.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
+
 import {
   Button,
   Space,
@@ -11,16 +12,18 @@ import {
 import { useSelector } from 'react-redux';
 
 import {
-  DownOutlined,
   CheckCircleOutlined,
 } from '@ant-design/icons';
 
 import PrettyTime from '../PrettyTime';
+import StepsIndicator from './StepsIndicator';
 import pipelineStatus from '../../utils/pipelineStatusValues';
 
 const { Text, Paragraph } = Typography;
 
-const StatusIndicator = () => {
+const StatusIndicator = (props) => {
+  const { allSteps, currentStep, completedSteps } = props;
+
   const {
     status: { pipeline },
   } = useSelector((state) => state.experimentSettings.backendStatus);
@@ -87,7 +90,7 @@ const StatusIndicator = () => {
       ),
     },
     [pipelineStatus.SUCCEEDED]: {
-      icon: <Text strong type='success'><CheckCircleOutlined /></Text>,
+      icon: <Text strong type='success' style={{ fontSize: '1.2rem' }}><CheckCircleOutlined /></Text>,
       title: <Text strong type='success'>finished</Text>,
       description: (
         <Text>
@@ -124,15 +127,25 @@ const StatusIndicator = () => {
   return (
     <Dropdown overlay={renderOverlay}>
       <Button type='text'>
-        <Space>
-          Status:
+        <Space size='small' direction='horizontal'>
+          <Text strong style={{ fontSize: '0.9rem' }}>
+            Status:
+          </Text>
+          <StepsIndicator
+            allSteps={allSteps}
+            currentStep={currentStep}
+            completedSteps={completedSteps}
+          />
           {statusIndicators[status].icon}
-          <Text type='secondary'><DownOutlined /></Text>
         </Space>
       </Button>
     </Dropdown>
   );
 };
 
-StatusIndicator.propTypes = {};
+StatusIndicator.propTypes = {
+  allSteps: PropTypes.array.isRequired,
+  currentStep: PropTypes.number.isRequired,
+  completedSteps: PropTypes.number.isRequired,
+};
 export default StatusIndicator;

--- a/src/components/data-processing/StatusIndicator.jsx
+++ b/src/components/data-processing/StatusIndicator.jsx
@@ -120,14 +120,16 @@ const StatusIndicator = (props) => {
       <Paragraph>
         {statusIndicators[status].description}
       </Paragraph>
-
     </Card>
   );
 
   return (
     <Dropdown overlay={renderOverlay}>
-      <Button type='text'>
-        <Space size='small' direction='horizontal'>
+      <Button
+        type='text'
+        style={{ paddingTop: '1px' }}
+      >
+        <Space size='small'>
           <Text strong style={{ fontSize: '0.9rem' }}>
             Status:
           </Text>
@@ -136,7 +138,9 @@ const StatusIndicator = (props) => {
             currentStep={currentStep}
             completedSteps={completedSteps}
           />
-          {statusIndicators[status].icon}
+          <div style={{ display: 'inline-block' }}>
+            {statusIndicators[status].icon}
+          </div>
         </Space>
       </Button>
     </Dropdown>

--- a/src/components/data-processing/StatusIndicator.jsx
+++ b/src/components/data-processing/StatusIndicator.jsx
@@ -118,6 +118,9 @@ const StatusIndicator = (props) => {
         </Text>
       </Paragraph>
       <Paragraph>
+        <Text>{`${completedSteps.length} of ${allSteps.length} steps complete`}</Text>
+      </Paragraph>
+      <Paragraph>
         {statusIndicators[status].description}
       </Paragraph>
     </Card>
@@ -136,7 +139,7 @@ const StatusIndicator = (props) => {
           <StepsIndicator
             allSteps={allSteps}
             currentStep={currentStep}
-            completedSteps={completedSteps}
+            completedSteps={completedSteps.length}
           />
           <div style={{ display: 'inline-block' }}>
             {statusIndicators[status].icon}

--- a/src/components/data-processing/StepsIndicator.jsx
+++ b/src/components/data-processing/StepsIndicator.jsx
@@ -5,8 +5,8 @@ const StepsIndicator = (props) => {
   const { allSteps, completedSteps, currentStep } = props;
   const colors = {
     notCompleted: '#d9d9d9', // gray
-    currentStep: '#cf1322', // red
-    completed: '#1890ff', // blue
+    currentStep: '#ff6f00', // orange
+    completed: '#009930', // blue
   };
   return (
     <div

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -482,18 +482,22 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
             </Col>
             <Col>
               {steps[stepIdx].multiSample && (
-                <Button
-                  disabled={stepDisabledByCondition}
-                  data-testid='enableFilterButton'
-                  onClick={() => {
-                    dispatch(setQCStepEnabled(steps[stepIdx].key, !processingConfig[steps[stepIdx].key]?.enabled));
-                    dispatch(saveProcessingSettings(experimentId, steps[stepIdx].key));
-                  }}>
-                  {
-                    !processingConfig[steps[stepIdx].key]?.enabled
-                      ? 'Enable' : 'Disable'
-                  }
-                </Button>
+                <Tooltip title={`${
+                    !processingConfig[steps[stepIdx].key]?.enabled ? 
+                    'Enable' : 'Disable'} this filter`}>
+                  <Button
+                    disabled={stepDisabledByCondition}
+                    data-testid='enableFilterButton'
+                    onClick={() => {
+                      dispatch(setQCStepEnabled(steps[stepIdx].key, !processingConfig[steps[stepIdx].key]?.enabled));
+                      dispatch(saveProcessingSettings(experimentId, steps[stepIdx].key));
+                    }}>
+                    {
+                      !processingConfig[steps[stepIdx].key]?.enabled
+                        ? 'Enable' : 'Disable'
+                    }
+                  </Button>
+                </Tooltip>
               )}
             </Col>
           </Row>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -507,10 +507,10 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               <StatusIndicator 
                 allSteps={steps}
                 currentStep={stepIdx}
-                completedSteps={completedSteps.length}
+                completedSteps={completedSteps}
               />
               <Space size='small'>
-                <Tooltip title='Previous filter'>
+                <Tooltip title='Previous'>
                   <Button
                     data-testid='pipelinePrevStep'
                     disabled={stepIdx === 0}
@@ -521,7 +521,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                   </Button>
                 </Tooltip>
                 {stepIdx !== steps.length - 1 ? (
-                  <Tooltip title='Next filter'>
+                  <Tooltip title='Next'>
                     <Button
                       data-testid='pipelineNextStep'
                       onClick={() => {

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -542,6 +542,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                         type='primary'
                         disabled={steps[stepIdx + 1] && pipelineNotFinished && !isStepComplete(steps[stepIdx + 1].key)}
                         icon={<CheckOutlined />}
+                        size="small"
                       >
                       </Button>
                       </Tooltip>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -31,7 +31,6 @@ import ConfigureEmbedding from '../../../../components/data-processing/Configure
 
 import PlatformError from '../../../../components/PlatformError';
 
-import StepsIndicator from '../../../../components/data-processing/StepsIndicator';
 import StatusIndicator from '../../../../components/data-processing/StatusIndicator';
 
 import SingleComponentMultipleDataContainer from '../../../../components/SingleComponentMultipleDataContainer';
@@ -509,16 +508,12 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
             </Col>
             <Col style={{ minHeight: '100%', alignItems: 'center', display: 'flex' }}>
               <Space>
-                <StepsIndicator
+                <StatusIndicator 
                   allSteps={steps}
                   currentStep={stepIdx}
                   completedSteps={completedSteps.length}
                 />
-                <Text>{`${completedSteps.length} of ${steps.length} steps complete`}</Text>
               </Space>
-            </Col>
-            <Col style={{ alignItems: 'center', display: 'flex' }}>
-              <StatusIndicator />
             </Col>
             <Col style={{ marginLeft: 'auto', alignItems: 'center', display: 'flex' }}>
               <Space size='small'>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -338,6 +338,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
         type='primary'
         onClick={() => setRunQCModalVisible(true)}
         style={{ minWidth: '80px' }}
+        size="small"
       >
         {runMessage}
       </Button>
@@ -350,10 +351,10 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
     } else if (changesOutstanding) {
       return (
         <Alert
-          message={<>Your new settings are <br />not yet applied</>}
+          message={<>Your new settings are not yet applied</>}
           type='info'
           showIcon
-          style={{ paddingTop: '0px', paddingBottom: '0px', paddingLeft: '10px', paddingRight: '10px' }}
+          style={{ paddingTop: '3px', paddingBottom: '3px', paddingLeft: '10px', paddingRight: '10px' }}
           action={
             <Space size='small'>
               {renderRunButton('Run')}
@@ -363,7 +364,8 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                   data-testid='discardChangesButton'
                   type='primary'
                   onClick={() => { dispatch(discardChangedQCFilters()); }}
-                  style={{ width: '80px' }}
+                  style={{ width: '80px'}}
+                  size="small"
                 >
                   Discard
                 </Button>
@@ -385,137 +387,128 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
 
   const renderTitle = () => (
     <>
-      <Row style={{ display: 'flex' }}>
-        <Col style={{ flex: 1, display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }} span={7}>
-          <Row style={{ display: 'flex' }} gutter={10}>
-            <Col>
-              {/* Should be just wide enough that no ellipsis appears */}
-              <Select
-                value={stepIdx}
-                onChange={(idx) => {
-                  changeStepId(idx);
-                }}
-                style={{ fontWeight: 'bold', width: 290 }}
-                placeholder='Jump to a step...'
-              >
-                {
-                  steps.map(
-                    ({ name, key }, i) => {
-                      const disabledByPipeline = (pipelineNotFinished && !isStepComplete(key));
-                      const text = `${i + 1}. ${name}`;
+      <Row justify="space-between">
+        <Col sm={24} xxl={changesOutstanding ? 7 : 10} style={{ paddingBottom: "8px"}}>
+          {/* Should be just wide enough that no ellipsis appears */}
+            <Space size="small">
+                <Select
+                  value={stepIdx}
+                  onChange={(idx) => {
+                    changeStepId(idx);
+                  }}
+                  style={{ fontWeight: 'bold', width: 290 }}
+                  placeholder='Jump to a step...'
+                >
+                  {
+                    steps.map(
+                      ({ name, key }, i) => {
+                        const disabledByPipeline = (pipelineNotFinished && !isStepComplete(key));
+                        const text = `${i + 1}. ${name}`;
 
-                      return (
-                        <Option
-                          value={i}
-                          key={key}
-                          disabled={
-                            disabledByPipeline
-                          }
-                        >
-                          {processingConfig[key]?.enabled === false ? (
-                            <>
-                              {/* disabled */}
-                              <Text
-                                type='secondary'
+                        return (
+                          <Option
+                            value={i}
+                            key={key}
+                            disabled={
+                              disabledByPipeline
+                            }
+                          >
+                            {processingConfig[key]?.enabled === false ? (
+                              <>
+                                {/* disabled */}
+                                <Text
+                                  type='secondary'
 
-                              >
-                                <CloseOutlined />
-                              </Text>
-                              <span
-                                style={{ marginLeft: '0.25rem', textDecoration: 'line-through' }}
-                              >
-                                {text}
-                              </span>
-                            </>
-                          ) : !disabledByPipeline ? (
-                            <>
-                              {/* finished */}
-                              <Text
-                                type='success'
+                                >
+                                  <CloseOutlined />
+                                </Text>
+                                <span
+                                  style={{ marginLeft: '0.25rem', textDecoration: 'line-through' }}
+                                >
+                                  {text}
+                                </span>
+                              </>
+                            ) : !disabledByPipeline ? (
+                              <>
+                                {/* finished */}
+                                <Text
+                                  type='success'
 
-                              >
-                                <CheckOutlined />
-                              </Text>
-                              <span
-                                style={{ marginLeft: '0.25rem' }}
-                              >
-                                {text}
-                              </span>
-                            </>
-                          ) : pipelineRunning && !isStepComplete(key) ? (
-                            <>
-                              {/* incomplete */}
-                              <Text
-                                type='warning'
-                                strong
-                              >
-                                <EllipsisOutlined />
-                              </Text>
-                              <span style={{ marginLeft: '0.25rem' }}>{text}</span>
-                            </>
-                          ) : pipelineNotFinished && !pipelineRunning && !isStepComplete(key) ? (
-                            <>
-                              {/* failed */}
-                              <Text
-                                type='danger'
-                                strong
-                              >
-                                <WarningOutlined />
-                              </Text>
-                              <span style={{ marginLeft: '0.25rem' }}>{text}</span>
-                            </>
-                          ) : <></>}
-                        </Option>
-                      );
-                    }
-                  )
-                }
-              </Select>
-            </Col>
-            <Col>
-              {steps[stepIdx].description && (
-                <Tooltip title={steps[stepIdx].description}>
-                  <Button icon={<InfoCircleOutlined />} />
-                </Tooltip>
-              )}
-            </Col>
-            <Col>
-              {steps[stepIdx].multiSample && (
-                <Tooltip title={`${
-                    !processingConfig[steps[stepIdx].key]?.enabled ? 
-                    'Enable' : 'Disable'} this filter`}>
-                  <Button
-                    disabled={stepDisabledByCondition}
-                    data-testid='enableFilterButton'
-                    onClick={() => {
-                      dispatch(setQCStepEnabled(steps[stepIdx].key, !processingConfig[steps[stepIdx].key]?.enabled));
-                      dispatch(saveProcessingSettings(experimentId, steps[stepIdx].key));
-                    }}>
-                    {
-                      !processingConfig[steps[stepIdx].key]?.enabled
-                        ? 'Enable' : 'Disable'
-                    }
-                  </Button>
-                </Tooltip>
-              )}
-            </Col>
-          </Row>
+                                >
+                                  <CheckOutlined />
+                                </Text>
+                                <span
+                                  style={{ marginLeft: '0.25rem' }}
+                                >
+                                  {text}
+                                </span>
+                              </>
+                            ) : pipelineRunning && !isStepComplete(key) ? (
+                              <>
+                                {/* incomplete */}
+                                <Text
+                                  type='warning'
+                                  strong
+                                >
+                                  <EllipsisOutlined />
+                                </Text>
+                                <span style={{ marginLeft: '0.25rem' }}>{text}</span>
+                              </>
+                            ) : pipelineNotFinished && !pipelineRunning && !isStepComplete(key) ? (
+                              <>
+                                {/* failed */}
+                                <Text
+                                  type='danger'
+                                  strong
+                                >
+                                  <WarningOutlined />
+                                </Text>
+                                <span style={{ marginLeft: '0.25rem' }}>{text}</span>
+                              </>
+                            ) : <></>}
+                          </Option>
+                        );
+                      }
+                    )
+                  }
+                </Select>
+                {steps[stepIdx].description && (
+                  <Tooltip title={steps[stepIdx].description}>
+                    <Button icon={<InfoCircleOutlined />} />
+                  </Tooltip>
+                )}
+                {steps[stepIdx].multiSample && (
+                  <Tooltip title={`${
+                      !processingConfig[steps[stepIdx].key]?.enabled ? 
+                      'Enable' : 'Disable'} this filter`}>
+                    <Button
+                      disabled={stepDisabledByCondition}
+                      data-testid='enableFilterButton'
+                      onClick={() => {
+                        dispatch(setQCStepEnabled(steps[stepIdx].key, !processingConfig[steps[stepIdx].key]?.enabled));
+                        dispatch(saveProcessingSettings(experimentId, steps[stepIdx].key));
+                      }}
+                      >
+                      {
+                        !processingConfig[steps[stepIdx].key]?.enabled
+                          ? 'Enable' : 'Disable'
+                      }
+                    </Button>
+                  </Tooltip>
+                )}
+                </Space>
         </Col>
-        <Col style={{ flex: 1, display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>
-          <Row>
-            <Col style={{ marginLeft: 'auto', marginRight: '10px' }}>
+        <Col sm={24} xxl={changesOutstanding ? 17 : 14}>
+          <Row align="middle" justify="space-between">
+            <Col>
               {renderRunOrDiscardButtons()}
             </Col>
-            <Col style={{ minHeight: '100%', alignItems: 'center', display: 'flex' }}>
-              <Space>
-                <StatusIndicator 
-                  allSteps={steps}
-                  currentStep={stepIdx}
-                  completedSteps={completedSteps.length}
-                />
-              </Space>
-            </Col>
-            <Col style={{ marginLeft: 'auto', alignItems: 'center', display: 'flex' }}>
+            <Col>
+              <StatusIndicator 
+                allSteps={steps}
+                currentStep={stepIdx}
+                completedSteps={completedSteps.length}
+              />
               <Space size='small'>
                 <Tooltip title='Previous filter'>
                   <Button
@@ -523,6 +516,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                     disabled={stepIdx === 0}
                     icon={<LeftOutlined />}
                     onClick={() => changeStepId(Math.max(stepIdx - 1, 0))}
+                    size="small"
                   >
                   </Button>
                 </Tooltip>
@@ -536,6 +530,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
                       }}
                       disabled={steps[stepIdx + 1] && pipelineNotFinished && !isStepComplete(steps[stepIdx + 1].key)}
                       icon={<RightOutlined />}
+                      size="small"
                     >
                   </Button>
                   </Tooltip>

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -521,37 +521,40 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
               <StatusIndicator />
             </Col>
             <Col style={{ marginLeft: 'auto', alignItems: 'center', display: 'flex' }}>
-              <Space size='middle'>
-                <Button
-                  data-testid='pipelinePrevStep'
-                  disabled={stepIdx === 0}
-                  icon={<LeftOutlined />}
-                  onClick={() => changeStepId(Math.max(stepIdx - 1, 0))}
-                >
-                  Previous
-                </Button>
-                {stepIdx !== steps.length - 1 ? (
+              <Space size='small'>
+                <Tooltip title='Previous filter'>
                   <Button
-                    data-testid='pipelineNextStep'
-                    onClick={() => {
-                      const newStepIdx = Math.min(stepIdx + 1, steps.length - 1);
-                      changeStepId(newStepIdx);
-                    }}
-                    disabled={steps[stepIdx + 1] && pipelineNotFinished && !isStepComplete(steps[stepIdx + 1].key)}
+                    data-testid='pipelinePrevStep'
+                    disabled={stepIdx === 0}
+                    icon={<LeftOutlined />}
+                    onClick={() => changeStepId(Math.max(stepIdx - 1, 0))}
                   >
-                    Next
-                    <RightOutlined />
                   </Button>
+                </Tooltip>
+                {stepIdx !== steps.length - 1 ? (
+                  <Tooltip title='Next filter'>
+                    <Button
+                      data-testid='pipelineNextStep'
+                      onClick={() => {
+                        const newStepIdx = Math.min(stepIdx + 1, steps.length - 1);
+                        changeStepId(newStepIdx);
+                      }}
+                      disabled={steps[stepIdx + 1] && pipelineNotFinished && !isStepComplete(steps[stepIdx + 1].key)}
+                      icon={<RightOutlined />}
+                    >
+                  </Button>
+                  </Tooltip>
                 )
                   : (
                     <Link as={completedPath.replace('[experimentId]', experimentId)} href={completedPath} passHref>
+                      <Tooltip title="Finish QC">
                       <Button
                         type='primary'
                         disabled={steps[stepIdx + 1] && pipelineNotFinished && !isStepComplete(steps[stepIdx + 1].key)}
+                        icon={<CheckOutlined />}
                       >
-                        <span style={{ marginRight: '0.25rem' }}>Finish</span>
-                        <CheckOutlined />
                       </Button>
+                      </Tooltip>
                     </Link>
                   )}
               </Space>

--- a/src/redux/reducers/experimentSettings/processingConfig/copyFilterSettingsToAllSamples.js
+++ b/src/redux/reducers/experimentSettings/processingConfig/copyFilterSettingsToAllSamples.js
@@ -9,16 +9,18 @@ const copyFilterSettingsToAllSamples = produce((draft, action) => {
 
   const sourceSettings = current(draft.processing[step][sourceSampleId]);
 
-  // Remove sourceSampleId because we don't want to set auto = false on it
+  // Remove sourceSampleId from the copied settings
   const index = sampleIds.indexOf(sourceSampleId);
   if (index > -1) {
     sampleIds.splice(index, 1);
   }
 
   sampleIds.forEach((sampleIdToReplace) => {
-    draft.processing[step][sampleIdToReplace].auto = false;
-    draft.processing[step][sampleIdToReplace]
-      .filterSettings = _.cloneDeep(sourceSettings.filterSettings);
+    draft.processing[step][sampleIdToReplace].auto = sourceSettings.auto;
+    if (!sourceSettings.auto) {
+      draft.processing[step][sampleIdToReplace]
+        .filterSettings = _.cloneDeep(sourceSettings.filterSettings);
+    }
   });
 }, initialState);
 


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1207

#### Link to staging deployment URL 

https://ui-agi-ui402.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

There are 4 main changes in this PR : 
- Add tooltips to the disable, prev and next buttons QC navigation buttons
- In multisample experiments, choosing "auto" settings and clicking "apply to all samples" will change the other sample's settings to auto
- Revamp QC navigation to fit new design, as specified in the mock up (link in Jira ticket)
- QC navigation should rearrange gracefully on small screens

These changes can be seen in the deployment URL.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [x] Approved by a member of the core engineering team
- [x] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [x] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR