### PR TITLE
[BIOMAGE-1203] Volcano plot labels should only be shown for significant genes

### DIFF
--- a/src/pages/experiments/[experimentId]/plots-and-tables/volcano/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/volcano/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { useEffect, useState, useRef } from 'react';
 import {
   Row,
@@ -279,7 +280,6 @@ const VolcanoPlot = ({ experimentId }) => {
     if (plotData.length === 0 || loading || _.isEmpty(spec.spec)) {
       return <Loader experimentId={experimentId} />;
     }
-
     return (
       <Vega data={{ data: plotData }} spec={spec.spec} renderer='canvas' />
     );

--- a/src/utils/plotSpecs/generateVolcanoSpec.js
+++ b/src/utils/plotSpecs/generateVolcanoSpec.js
@@ -52,7 +52,7 @@ const generateSpec = (configSrc, data) => {
     ? [0, config.maxNegativeLogpValueDomain]
     : { data: 'data', field: 'neglogpvalue' };
 
-  // adding gene labels above the set Y value only for the signi
+  // adding gene labels above the set Y value only for the significant genes
   const textEquation = `datum.avg_log2FC !== 'NA' && (datum.neglogpvalue >${config.textThresholdValue} && (datum.status == 'Upregulated' || datum.status == 'Downregulated'))`;
 
   let legend = [];

--- a/src/utils/plotSpecs/generateVolcanoSpec.js
+++ b/src/utils/plotSpecs/generateVolcanoSpec.js
@@ -52,7 +52,9 @@ const generateSpec = (configSrc, data) => {
     ? [0, config.maxNegativeLogpValueDomain]
     : { data: 'data', field: 'neglogpvalue' };
 
-  const textEquation = `datum.avg_log2FC !== 'NA' && datum.neglogpvalue >${config.textThresholdValue}`;
+  // adding gene labels above the set Y value only for the signi
+  const textEquation = `datum.avg_log2FC !== 'NA' && (datum.neglogpvalue >${config.textThresholdValue} && (datum.status == 'Upregulated' || datum.status == 'Downregulated'))`;
+
   let legend = [];
   if (config.legend.enabled) {
     legend = [
@@ -252,7 +254,7 @@ const generateSpec = (configSrc, data) => {
             x: { scale: 'x', field: 'avg_log2FC' },
             y: { scale: 'y', field: 'neglogpvalue' },
 
-            fill: config.colour.masterColour,
+            fill: { value: config.colour.masterColour },
             text: { field: 'gene_names' },
           },
           transform: [

--- a/src/utils/plotSpecs/generateVolcanoSpec.js
+++ b/src/utils/plotSpecs/generateVolcanoSpec.js
@@ -53,7 +53,7 @@ const generateSpec = (configSrc, data) => {
     : { data: 'data', field: 'neglogpvalue' };
 
   // adding gene labels above the set Y value only for the significant genes
-  const textEquation = `datum.avg_log2FC !== 'NA' && (datum.neglogpvalue >${config.textThresholdValue} && (datum.status == 'Upregulated' || datum.status == 'Downregulated'))`;
+  const geneLabelsEquation = `datum.avg_log2FC !== 'NA' && (datum.neglogpvalue >${config.textThresholdValue} && (datum.status == 'Upregulated' || datum.status == 'Downregulated'))`;
 
   let legend = [];
   if (config.legend.enabled) {
@@ -125,7 +125,7 @@ const generateSpec = (configSrc, data) => {
         transform: [
           {
             type: 'filter',
-            expr: textEquation,
+            expr: geneLabelsEquation,
           }],
       },
 


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-1203
#### Link to staging deployment URL 
https://ui-stefan-ui413.scp-staging.biomage.net/experiments/stefan-ui413-23fda7e0fb5d86956c2840b401072a5d/data-processing
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
