### PR TITLE
[BIOMAGE-1237] Rename Data Management tiles

### DIFF
--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -86,7 +86,7 @@ const DataManagementPage = ({ route }) => {
   };
 
   const TILE_MAP = {
-    'Projects List': {
+    'Projects': {
       toolbarControls: [],
       component: (width, height) => (
         <Space
@@ -102,7 +102,7 @@ const DataManagementPage = ({ route }) => {
         </Space>
       ),
     },
-    'Data Management': {
+    'Samples': {
       toolbarControls: [],
       component: (width, height) => (
         <ProjectDetails width={width} height={height} />
@@ -112,8 +112,8 @@ const DataManagementPage = ({ route }) => {
 
   const windows = {
     direction: 'row',
-    first: 'Projects List',
-    second: 'Data Management',
+    first: 'Projects',
+    second: 'Samples',
     splitPercentage: 23,
   };
 

--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -85,8 +85,11 @@ const DataManagementPage = ({ route }) => {
     setNewProjectModalVisible(false);
   };
 
-  const TILE_MAP = {
-    'Projects': {
+  const PROJECTS_LIST = 'Projects'
+  const PROJECT_DETAILS = 'Project Details'
+
+  let TILE_MAP = {
+    [PROJECTS_LIST]: {
       toolbarControls: [],
       component: (width, height) => (
         <Space
@@ -102,7 +105,7 @@ const DataManagementPage = ({ route }) => {
         </Space>
       ),
     },
-    'Samples': {
+    [PROJECT_DETAILS]: {
       toolbarControls: [],
       component: (width, height) => (
         <ProjectDetails width={width} height={height} />
@@ -112,8 +115,8 @@ const DataManagementPage = ({ route }) => {
 
   const windows = {
     direction: 'row',
-    first: 'Projects',
-    second: 'Samples',
+    first: PROJECTS_LIST,
+    second: PROJECT_DETAILS,
     splitPercentage: 23,
   };
 


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1237
#### Link to staging deployment URL 
https://ui-james-ui415.scp-staging.biomage.net/
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
The ticket recommended changing 'Data Management' to 'Samples List', I presume to match the existing 'Projects List'. However I reasoned that for both of these, 'List' is redundant, so changed them to 'Samples' and 'Projects' respectively.
# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
