### PR TITLE
fix classifier legend

### DIFF
--- a/src/utils/plotSpecs/generateClassifierKneePlot.js
+++ b/src/utils/plotSpecs/generateClassifierKneePlot.js
@@ -152,7 +152,7 @@ const generateSpec = (config, { FDR }, plotData) => {
         name: 'color',
         type: 'ordinal',
         range: ['green', 'lightgray', '#f57b42'],
-        domain: ['above', 'mixed', 'below'],
+        domain: ['below', 'mixed', 'above'],
       },
       {
         name: 'keep',


### PR DESCRIPTION
The legend labels are mixed up:

![image](https://user-images.githubusercontent.com/15719520/128552023-f850fec4-449f-42d2-8b9b-5c437e516a4e.png)


green should be "below" and orange should be "above"