### PR TITLE
[BIOMAGE-1267] - Hide cluster legend in categorical embedding plots

### DIFF
--- a/src/__test__/redux/reducers/componentConfig/__snapshots__/updateConfig.test.js.snap
+++ b/src/__test__/redux/reducers/componentConfig/__snapshots__/updateConfig.test.js.snap
@@ -30,13 +30,13 @@ Object {
         "colour": "#000000",
         "font": "sans-serif",
       },
-      "label": Object {
-        "enabled": true,
-        "size": 28,
+      "labels": Object {
+        "enabled": false,
+        "size": 18,
       },
       "legend": Object {
         "colour": "#000000",
-        "enabled": false,
+        "enabled": true,
         "position": "top",
       },
       "marker": Object {
@@ -93,9 +93,9 @@ Object {
         "font": "sans-serif",
       },
       "height": 2000,
-      "label": Object {
+      "labels": Object {
         "enabled": true,
-        "size": 28,
+        "size": 18,
       },
       "legend": Object {
         "colour": "#000000",

--- a/src/__test__/redux/reducers/componentConfig/__snapshots__/updateConfig.test.js.snap
+++ b/src/__test__/redux/reducers/componentConfig/__snapshots__/updateConfig.test.js.snap
@@ -36,7 +36,7 @@ Object {
       },
       "legend": Object {
         "colour": "#000000",
-        "enabled": true,
+        "enabled": false,
         "position": "top",
       },
       "marker": Object {

--- a/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
+++ b/src/components/data-processing/ConfigureEmbedding/ConfigureEmbedding.jsx
@@ -61,7 +61,7 @@ const ConfigureEmbedding = (props) => {
       title: 'Colored by CellSets',
       plotUuid: generateDataProcessingPlotUuid(null, filterName, 0),
       plotType: 'embeddingPreviewByCellSets',
-      plot: (config, [], actions) => (
+      plot: (config, plotData, actions) => (
         <CategoricalEmbeddingPlot
           experimentId={experimentId}
           config={config}
@@ -74,7 +74,7 @@ const ConfigureEmbedding = (props) => {
       title: 'Colored by Samples',
       plotUuid: generateDataProcessingPlotUuid(null, filterName, 1),
       plotType: 'embeddingPreviewBySample',
-      plot: (config, [], actions) => (
+      plot: (config, plotData, actions) => (
         <CategoricalEmbeddingPlot
           experimentId={experimentId}
           config={{
@@ -93,7 +93,7 @@ const ConfigureEmbedding = (props) => {
       title: 'Mitochondrial fraction reads',
       plotUuid: generateDataProcessingPlotUuid(null, filterName, 2),
       plotType: 'embeddingPreviewMitochondrialContent',
-      plot: (config, [], actions) => (
+      plot: (config, plotData, actions) => (
         <ContinuousEmbeddingPlot
           experimentId={experimentId}
           config={config}
@@ -110,7 +110,7 @@ const ConfigureEmbedding = (props) => {
       title: 'Cell doublet score',
       plotUuid: generateDataProcessingPlotUuid(null, filterName, 3),
       plotType: 'embeddingPreviewDoubletScore',
-      plot: (config, [], actions) => (
+      plot: (config, plotData, actions) => (
         <ContinuousEmbeddingPlot
           experimentId={experimentId}
           config={config}
@@ -280,13 +280,20 @@ const ConfigureEmbedding = (props) => {
       return;
     }
 
+    const plotActions = {
+      export: true,
+      source: false,
+      compiled: false,
+      editor: false,
+    };
+
     if (!cellSets.loading
       && !cellSets.error
       && !cellSets.updateCellSetsClustering
       && selectedConfig
       && plotData
     ) {
-      setPlot(plots[selectedPlot].plot(selectedConfig, plotData));
+      setPlot(plots[selectedPlot].plot(selectedConfig, plotData, plotActions));
     }
   }, [selectedConfig, cellSets, plotData]);
 

--- a/src/components/plots/MiniPlot.jsx
+++ b/src/components/plots/MiniPlot.jsx
@@ -22,7 +22,7 @@ const getMiniaturizedConfig = (config) => {
     marker: {
       size: 1,
     },
-    label: {
+    labels: {
       enabled: false,
     },
   };
@@ -42,12 +42,8 @@ const MiniPlot = (props) => {
     plotUuid, plotFn, actions,
   } = props;
 
-  const config = useSelector(
-    (state) => state.componentConfig[plotUuid]?.config,
-  );
-
-  const plotData = useSelector(
-    (state) => state.componentConfig[plotUuid]?.plotData,
+  const { config, plotData } = useSelector(
+    (state) => state.componentConfig[plotUuid] || {},
   );
 
   const renderPlot = () => {
@@ -59,7 +55,7 @@ const MiniPlot = (props) => {
       );
     }
 
-    return plotFn(getMiniaturizedConfig(config), plotData, actions);
+    return plotFn(getMiniaturizedConfig(config), plotData || [], actions);
   };
 
   return (

--- a/src/components/plots/styling/LabelsDesign.jsx
+++ b/src/components/plots/styling/LabelsDesign.jsx
@@ -32,7 +32,7 @@ const LabelsDesign = (props) => {
           max={maxLabelSize}
           disabled={!config.labels.enabled}
           onChange={(value) => {
-            handleChange({ label: { size: value } });
+            handleChange({ labels: { size: value } });
           }}
           marks={{ 0: minLabelSize, 50: maxLabelSize }}
         />

--- a/src/components/plots/styling/LabelsDesign.jsx
+++ b/src/components/plots/styling/LabelsDesign.jsx
@@ -16,7 +16,7 @@ const LabelsDesign = (props) => {
 
       <p><strong>Toggle Labels</strong></p>
       <Form.Item>
-        <Radio.Group onChange={(e) => onUpdate({ label: { enabled: e.target.value } })} value={config.label.enabled}>
+        <Radio.Group onChange={(e) => onUpdate({ labels: { enabled: e.target.value } })} value={config.labels.enabled}>
           <Radio value>Show</Radio>
           <Radio value={false}>Hide</Radio>
         </Radio.Group>
@@ -27,10 +27,10 @@ const LabelsDesign = (props) => {
         label='Size'
       >
         <Slider
-          value={newConfig.label.size}
+          value={newConfig.labels.size}
           min={minLabelSize}
           max={maxLabelSize}
-          disabled={!config.label.enabled}
+          disabled={!config.labels.enabled}
           onChange={(value) => {
             handleChange({ label: { size: value } });
           }}

--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import Link from 'next/link';

--- a/src/redux/actions/componentConfig/loadPlotConfig.js
+++ b/src/redux/actions/componentConfig/loadPlotConfig.js
@@ -18,6 +18,7 @@ const loadPlotConfig = (experimentId, plotUuid, plotType) => async (dispatch) =>
       dispatch({
         type: LOAD_CONFIG,
         payload: {
+          plotData: [],
           ...data,
           plotType,
           config,

--- a/src/redux/reducers/componentConfig/baseStylesState.js
+++ b/src/redux/reducers/componentConfig/baseStylesState.js
@@ -49,7 +49,7 @@ const markerBaseState = {
 
 const labelBaseState = {
   enabled: true,
-  size: 28,
+  size: 18,
 };
 
 export {

--- a/src/redux/reducers/componentConfig/initialState.js
+++ b/src/redux/reducers/componentConfig/initialState.js
@@ -14,6 +14,7 @@ const embeddingCategoricalInitialConfig = {
   spec: '1.0.0',
   legend: {
     ...legendBaseState,
+    enabled: false,
     position: 'top',
   },
   dimensions: {
@@ -237,6 +238,7 @@ const embeddingPreviewByCellSetsInitialConfig = {
   spec: '1.0.0',
   legend: {
     ...legendBaseState,
+    enabled: false,
     position: 'top',
   },
   dimensions: {

--- a/src/redux/reducers/componentConfig/initialState.js
+++ b/src/redux/reducers/componentConfig/initialState.js
@@ -14,7 +14,6 @@ const embeddingCategoricalInitialConfig = {
   spec: '1.0.0',
   legend: {
     ...legendBaseState,
-    enabled: false,
     position: 'top',
   },
   dimensions: {
@@ -35,7 +34,10 @@ const embeddingCategoricalInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: {
+    ...labelBaseState,
+    enabled: false,
+  },
   selectedCellSet: 'louvain',
   selectedSample: 'All',
 };
@@ -63,7 +65,7 @@ const embeddingContinuousInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   logEquation: 'datum.expression*1',
   shownGene: 'notSelected',
   selectedSample: 'All',
@@ -90,7 +92,7 @@ const heatmapInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   selectedGenes: [],
   selectedCellSet: 'louvain',
   labelColour: 'transparent',
@@ -119,7 +121,7 @@ const volcanoInitialConfig = {
   title: titleBaseState,
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   noDifferenceColor: '#aaaaaa',
   significantUpregulatedColor: '#0000ffaa',
   significantDownregulatedColor: '#ff0000',
@@ -152,7 +154,7 @@ const frequencyInitialConfig = {
     position: 'top',
     offset: 40,
   },
-  label: labelBaseState,
+  labels: labelBaseState,
   dimensions: dimensionsBaseState,
   marker: markerBaseState,
   colour: colourBaseState,
@@ -194,7 +196,7 @@ const violinConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   shownGene: 'notSelected',
   selectedCellSet: 'louvain',
   selectedPoints: 'All',
@@ -228,7 +230,10 @@ const embeddingPreviewBySampleInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: {
+    ...labelBaseState,
+    enabled: false,
+  },
   selectedCellSet: 'louvain',
   selectedSample: 'All',
 };
@@ -238,7 +243,6 @@ const embeddingPreviewByCellSetsInitialConfig = {
   spec: '1.0.0',
   legend: {
     ...legendBaseState,
-    enabled: false,
     position: 'top',
   },
   dimensions: {
@@ -259,7 +263,10 @@ const embeddingPreviewByCellSetsInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: {
+    ...labelBaseState,
+    enabled: false,
+  },
   selectedCellSet: 'louvain',
   selectedSample: 'All',
 };
@@ -287,7 +294,7 @@ const embeddingPreviewMitochondrialContentInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   selectedSample: 'sample',
 };
 
@@ -314,7 +321,7 @@ const embeddingPreviewDoubletScoreInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   selectedSample: 'sample',
 };
 
@@ -349,7 +356,7 @@ const cellSizeDistributionHistogram = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   minCellSize: 10800,
   binStep: 200,
 };
@@ -378,7 +385,7 @@ const cellSizeDistributionKneePlot = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   minCellSize: 990,
 };
 
@@ -407,7 +414,7 @@ const mitochondrialFractionHistogram = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   binStep: 0.05,
   maxFraction: 0.1,
 };
@@ -437,7 +444,7 @@ const mitochondrialFractionLogHistogram = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   binStep: 0.05,
   maxFraction: 0.2,
 };
@@ -466,7 +473,7 @@ const classifierKneePlot = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   minCellSize: 990,
 };
 
@@ -495,7 +502,7 @@ const classifierEmptyDropsPlot = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   minProbability: 0.82,
   bandwidth: -1,
 };
@@ -520,7 +527,7 @@ const featuresVsUMIsScatterplot = {
   },
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   lower_cutoff: 4.8,
   upper_cutoff: 2.1,
 };
@@ -549,7 +556,7 @@ const doubletScoreHistogram = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   binStep: 0.05,
   probThreshold: 0.2,
 };
@@ -579,7 +586,7 @@ const dataIntegrationEmbeddingInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  label: labelBaseState,
+  labels: labelBaseState,
   selectedCellSet: 'louvain',
   selectedSample: 'All',
 };
@@ -616,7 +623,7 @@ const dataIntegrationElbowPlotInitialConfig = {
     ...legendBaseState,
     position: 'top',
   },
-  label: { ...labelBaseState },
+  labels: labelBaseState,
   dimensions: {
     ...dimensionsBaseState,
     width: 700,

--- a/src/redux/reducers/componentConfig/initialState.js
+++ b/src/redux/reducers/componentConfig/initialState.js
@@ -586,7 +586,10 @@ const dataIntegrationEmbeddingInitialConfig = {
   fontStyle: fontStyleBaseState,
   colour: colourBaseState,
   marker: markerBaseState,
-  labels: labelBaseState,
+  labels: {
+    ...labelBaseState,
+    enabled: false,
+  },
   selectedCellSet: 'louvain',
   selectedSample: 'All',
 };

--- a/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
+++ b/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
@@ -43,7 +43,7 @@ const generateSpec = (config, plotData) => {
     $schema: 'https://vega.github.io/schema/vega/v5.json',
     width: config?.dimensions.width,
     height: config?.dimensions.height,
-    autosize: 'fit',
+    autosize: { type: 'fit', resize: true },
     background: config?.colour.toggleInvert,
     padding: 5,
     data: [
@@ -158,16 +158,13 @@ const generateSpec = (config, plotData) => {
           enter: {
             x: { scale: 'x', field: 'meanX' },
             y: { scale: 'y', field: 'meanY' },
-            text: { scale: 'sampleToName', field: 'cluster' },
-            fontSize: config?.label.size,
-            strokeWidth: 1.2,
-            fill: config?.colour.masterColour,
-            fillOpacity: config?.label.enabled,
-            font: config?.fontStyle.font,
-
+            text: { field: 'cluster' },
+            fontSize: { value: config?.labels.size },
+            strokeWidth: { value: 1.2 },
+            fill: { value: config?.colour.masterColour },
+            fillOpacity: { value: config?.labels.enabled },
+            font: { value: config?.fontStyle.font },
           },
-          transform: [
-            { type: 'label', size: ['width', 'height'] }],
         },
       },
     ],


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1267

#### Link to staging deployment URL 

https://ui-agi-ui430.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- Hide legends by default in the 1st plot of configure embedding, and also in Plots and Tables Categorical Embedding
- New settings apply for new experiments, because settings for old experiments are working

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
