### PR TITLE
[BIOMAGE-1266] - Rotate X axis labels

### DIFF
--- a/src/components/plots/styling/AxesDesign.jsx
+++ b/src/components/plots/styling/AxesDesign.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Slider, Form, Input, Radio, Switch,
+  Slider, Form, Input, Switch,
 } from 'antd';
 import useUpdateThrottled from '../../../utils/customHooks/useUpdateThrottled';
 
@@ -50,10 +50,9 @@ const AxesDesign = (props) => {
         <Switch
           checked={newConfig.axes.xAxisRotateLabels}
           onChange={(checked) => {
-              handleChange({ axes: { xAxisRotateLabels: checked } })
-            }}
-          >
-        </Switch>
+            handleChange({ axes: { xAxisRotateLabels: checked } });
+          }}
+        />
       </Form.Item>
 
       <Form.Item label='Axes Label Size'>

--- a/src/redux/reducers/componentConfig/initialState.js
+++ b/src/redux/reducers/componentConfig/initialState.js
@@ -160,6 +160,7 @@ const frequencyInitialConfig = {
     ...axesBaseState,
     xAxisText: 'Sample',
     yAxisText: 'Proportion',
+    xAxisRotateLabels: true,
     offset: 10,
   },
   fontStyle: fontStyleBaseState,
@@ -184,6 +185,7 @@ const violinConfig = {
   axes: {
     ...axesBaseState,
     offset: 10,
+    xAxisRotateLabels: true,
   },
   title: {
     ...titleBaseState,
@@ -603,6 +605,7 @@ const dataIntegrationFrequencyInitialConfig = {
     ...axesBaseState,
     xAxisText: 'Louvain clusters',
     yAxisText: 'Proportion',
+    xAxisRotateLabels: true,
     offset: 10,
   },
   fontStyle: fontStyleBaseState,


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1266

#### Link to staging deployment URL 

https://ui-agi-ui431.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

Rotate X axis labels by default for :
- Frequency plot in Data Integration
- Frequency plot in Plots and Tables
- Violin plot

The new settings (rotate X axis by deafult) will only be set for new experiments because old experiments will use saved plot settings (non-rotated X axis)

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
