### PR TITLE
Fix erroneous backend status request

### DIFF
--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -71,7 +71,12 @@ const DataManagementPage = ({ route }) => {
     // ID so the experiments load will fail this should be addressed by migrating experiments.
     // However, for now, if the activeProjectUuid is not a Uuid it means that it's an old experiment
     // and we should not try to load the experiments with it
-    if (!activeProjectUuid || !isUuid(activeProjectUuid)) return;
+    if (
+      !activeProjectUuid
+      || !isUuid(activeProjectUuid)
+      || !projectsList[activeProjectUuid]?.experiments
+      || !projectsList[activeProjectUuid]?.experiments[0]
+    ) return;
 
     // Right now we have one experiment per project, so we can just load the experiment
     // This has to be changed when we have more than one experiment

--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -77,8 +77,9 @@ const DataManagementPage = ({ route }) => {
     // This has to be changed when we have more than one experiment
     const activeExperimentId = projectsList[activeProjectUuid].experiments[0];
 
+    dispatch(loadProcessingSettings(activeExperimentId));
+
     if (!experimentsAreLoaded) {
-      dispatch(loadProcessingSettings(activeExperimentId));
       dispatch(loadExperiments(activeProjectUuid)).then(() => updateRunStatus(activeExperimentId));
     }
 

--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -67,13 +67,6 @@ const DataManagementPage = ({ route }) => {
   };
 
   useEffect(() => {
-    if (activeProject?.experiments.length > 0) {
-      // Right now we have one experiment per project, so we can just load the experiment
-      // This has to be changed when we have more than one experiment
-      const activeExperimentId = activeProject.experiments[0];
-      dispatch(loadProcessingSettings(activeExperimentId));
-    }
-
     // old experiments don't have a project so the activeProjectUuid will actually be an experiment
     // ID so the experiments load will fail this should be addressed by migrating experiments.
     // However, for now, if the activeProjectUuid is not a Uuid it means that it's an old experiment
@@ -82,14 +75,15 @@ const DataManagementPage = ({ route }) => {
 
     // Right now we have one experiment per project, so we can just load the experiment
     // This has to be changed when we have more than one experiment
-    const activeExperimentId = activeProject.experiments[0];
+    const activeExperimentId = projectsList[activeProjectUuid].experiments[0];
 
     if (!experimentsAreLoaded) {
+      dispatch(loadProcessingSettings(activeExperimentId));
       dispatch(loadExperiments(activeProjectUuid)).then(() => updateRunStatus(activeExperimentId));
     }
 
     if (experiments[activeExperimentId]) updateRunStatus(activeExperimentId);
-  }, [activeProject, samples]);
+  }, [activeProjectUuid]);
 
   useEffect(() => {
     if (projectsLoading === true) {


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

https://ui-agi-ui433.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

The UI is requesting a lot of backend status requests when uploading sample. This is because the call to check the backend status depends on the `samples` variable which is actually not required.

![image](https://user-images.githubusercontent.com/2862362/129009212-c8c392b3-b36d-40da-bf53-2d5ef3bd2698.png)

With the fix, the backend request does not fire anymore when uploading samples: 

![image](https://user-images.githubusercontent.com/2862362/129013473-d41507bc-e5ab-46a2-850b-9ed663b9cf93.png)



# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [x] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
