### PR TITLE
[BIOMAGE-1299] Increase the timeout for all tasks sent to the worker

### DIFF
--- a/src/__test__/components/data-exploration/gene-list-tool/GeneListTool.test.jsx
+++ b/src/__test__/components/data-exploration/gene-list-tool/GeneListTool.test.jsx
@@ -163,7 +163,6 @@ describe('GeneListTool', () => {
         selectFields: ['gene_names', 'dispersions'],
       },
       backendStatus.status,
-      { timeout: 30 },
     );
 
     expect(store.getActions()[0]).toMatchSnapshot();

--- a/src/__test__/components/data-exploration/generic-gene-table/ComponentActions.test.jsx
+++ b/src/__test__/components/data-exploration/generic-gene-table/ComponentActions.test.jsx
@@ -151,7 +151,6 @@ describe('ComponentActions', () => {
         genes: ['A', 'B', 'C'],
       },
       backendStatus.status,
-      { timeout: 30 },
     );
 
     expect(store.getActions().length).toEqual(2);

--- a/src/__test__/redux/actions/genes/__snapshots__/loadGeneExpression.test.js.snap
+++ b/src/__test__/redux/actions/genes/__snapshots__/loadGeneExpression.test.js.snap
@@ -120,9 +120,6 @@ exports[`loadGeneExpression action Does not send work for already loaded express
           "status": "SUCCEEDED",
         },
       },
-      Object {
-        "timeout": 30,
-      },
     ],
   ],
   "results": Array [
@@ -152,9 +149,6 @@ exports[`loadGeneExpression action Sends work for already loaded expression data
           "status": "SUCCEEDED",
         },
       },
-      Object {
-        "timeout": 30,
-      },
     ],
     Array [
       "1234",
@@ -171,9 +165,6 @@ exports[`loadGeneExpression action Sends work for already loaded expression data
           "startDate": "2021-01-01T01:01:01.000Z",
           "status": "SUCCEEDED",
         },
-      },
-      Object {
-        "timeout": 30,
       },
     ],
   ],

--- a/src/__test__/redux/actions/genes/__snapshots__/loadPaginatedGeneProperties.test.js.snap
+++ b/src/__test__/redux/actions/genes/__snapshots__/loadPaginatedGeneProperties.test.js.snap
@@ -35,7 +35,7 @@ exports[`loadPaginatedGeneProperties action Dispatches appropriately on success 
   "calls": Array [
     Array [
       "1234",
-      30,
+      180,
       Object {
         "limit": 20,
         "name": "ListGenes",

--- a/src/redux/actions/cellMeta/loadCellMeta.js
+++ b/src/redux/actions/cellMeta/loadCellMeta.js
@@ -35,7 +35,7 @@ const loadCellMeta = (
 
   try {
     const data = await fetchCachedWork(
-      experimentId, body, backendStatus.status, { timeout: 30 },
+      experimentId, body, backendStatus.status,
     );
     dispatch({
       type: CELL_META_LOADED,

--- a/src/redux/actions/embedding/loadEmbedding.js
+++ b/src/redux/actions/embedding/loadEmbedding.js
@@ -1,8 +1,6 @@
 import { EMBEDDINGS_LOADING, EMBEDDINGS_LOADED, EMBEDDINGS_ERROR } from '../../actionTypes/embeddings';
 import { fetchCachedWork } from '../../../utils/cacheRequest';
 
-const REQUEST_TIMEOUT = 180;
-
 const loadEmbedding = (
   experimentId,
   embeddingType,
@@ -47,7 +45,7 @@ const loadEmbedding = (
 
   try {
     const data = await fetchCachedWork(
-      experimentId, body, backendStatus.status, { timeout: REQUEST_TIMEOUT },
+      experimentId, body, backendStatus.status,
     );
     return dispatch({
       type: EMBEDDINGS_LOADED,

--- a/src/redux/actions/genes/loadGeneExpression.js
+++ b/src/redux/actions/genes/loadGeneExpression.js
@@ -64,7 +64,7 @@ const loadGeneExpression = (
 
   try {
     const data = await fetchCachedWork(
-      experimentId, body, backendStatus.status, { timeout: 30 },
+      experimentId, body, backendStatus.status,
     );
 
     if (data[genesToFetch[0]]?.error) {

--- a/src/redux/actions/genes/loadPaginatedGeneProperties.js
+++ b/src/redux/actions/genes/loadPaginatedGeneProperties.js
@@ -8,8 +8,6 @@ import {
 
 import { fetchCachedWork } from '../../../utils/cacheRequest';
 
-const TIMEOUT_SECONDS = 30;
-
 const loadPaginatedGeneProperties = (
   experimentId, properties, componentUuid, tableState,
 ) => async (dispatch, getState) => {
@@ -46,7 +44,7 @@ const loadPaginatedGeneProperties = (
 
   try {
     const { rows, total } = await fetchCachedWork(
-      experimentId, body, backendStatus.status, { timeout: TIMEOUT_SECONDS },
+      experimentId, body, backendStatus.status,
     );
 
     const loadedProperties = {};

--- a/src/utils/cacheRequest.js
+++ b/src/utils/cacheRequest.js
@@ -82,7 +82,7 @@ const fetchCachedWork = async (
   backendStatus,
   optionals = {},
 ) => {
-  const { extras = undefined, timeout = 60 } = optionals;
+  const { extras = undefined, timeout = 180 } = optionals;
 
   if (!isBrowser) {
     throw new Error('Disabling network interaction on server');


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1299

#### Link to staging deployment URL 
https://ui-bigger-timeouts.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
For big datasets like David Waxman's one, the worker takes more time to download the r object. As a temporary measure, we need to increase the timeout on the UI and also the timeout on the worker (done as part of this PR: https://github.com/biomage-ltd/worker/pull/169) so that the task gets returned. 
As a long-term measure, we should develop a smarter timeouts mechanism that assigns a timeout based on the size of the dataset. This will be done as part of future work.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
