### PR TITLE
Only showing up new project modal when the user logs in

### DIFF
--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -35,6 +35,7 @@ const DataManagementPage = ({ route }) => {
   } = useSelector((state) => state.projects.meta);
   const experiments = useSelector((state) => state.experiments);
   const [newProjectModalVisible, setNewProjectModalVisible] = useState(false);
+  const [justLoggedIn, setJustLoggedIn] = useState(true);
   const activeProject = projectsList[activeProjectUuid];
 
   const existingExperiments = activeProject?.experiments
@@ -92,13 +93,15 @@ const DataManagementPage = ({ route }) => {
   }, [activeProjectUuid]);
 
   useEffect(() => {
-    if (projectsLoading === true) {
+    // only open the modal the first time a user logs in if there are no projects
+    if (justLoggedIn === false || projectsLoading === true) {
       return;
     }
+
+    setJustLoggedIn(false);
+
     if (projectsList.ids.length === 0) {
       setNewProjectModalVisible(true);
-    } else {
-      setNewProjectModalVisible(false);
     }
   }, [projectsList, projectsLoading]);
 


### PR DESCRIPTION
The modal pops in and out because of the logic making it appear on project delete. It's a mess because experiments / projects are updated all over the place so we can't reliably know when to display it. The compromise solution is to just show it up the first time the user logs in. 

**Note** this is needed to have reliable integration tests.