### PR TITLE
[BIOMAGE-1297] added matomo tag manager

### DIFF
--- a/src/components/TagManager.jsx
+++ b/src/components/TagManager.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Head from 'next/head';
 import { getTrackingDetails } from '../utils/tracking';
 
@@ -18,6 +19,10 @@ const TagManager = ({ environment }) => {
       <script key='mtm' dangerouslySetInnerHTML={{ __html: mtmTrackingCode }} />
     </Head>
   );
+};
+
+TagManager.propTypes = {
+  environment: PropTypes.oneOf(['environment', 'staging', 'production']).isRequired,
 };
 
 export default TagManager;

--- a/src/components/TagManager.jsx
+++ b/src/components/TagManager.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Head from 'next/head';
+import { getTrackingDetails } from '../utils/tracking';
+
+const TagManager = ({ environment }) => {
+  const { enabled, containerId } = getTrackingDetails(environment);
+
+  // if tracking is not enabled don't add tag manager to the head
+  if (!enabled) return (null);
+
+  const mtmTrackingCode = `var _mtm = window._mtm = window._mtm || [];
+          _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+          var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+          g.async=true; g.src='https://cdn.matomo.cloud/biomage.matomo.cloud/container_${containerId}.js'; s.parentNode.insertBefore(g,s);`;
+
+  return (
+    <Head>
+      <script key='mtm' dangerouslySetInnerHTML={{ __html: mtmTrackingCode }} />
+    </Head>
+  );
+};
+
+export default TagManager;

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -26,7 +26,6 @@ import AnalysisModal from './AnalysisModal';
 import UploadDetailsModal from './UploadDetailsModal';
 import MetadataPopover from './MetadataPopover';
 
-import { trackAnalysisLaunched } from '../../utils/tracking';
 import { getFromUrlExpectOK } from '../../utils/getDataExpectOK';
 import {
   deleteSamples, updateSample,
@@ -597,7 +596,6 @@ const ProjectDetails = ({ width, height }) => {
   };
 
   const launchAnalysis = async (experimentId) => {
-    trackAnalysisLaunched();
     await dispatch(runGem2s(experimentId));
     router.push(analysisPath.replace('[experimentId]', experimentId));
   };

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -11,6 +11,7 @@ import AWS from 'aws-sdk';
 import { Credentials } from '@aws-amplify/core';
 import { initTracking } from '../utils/tracking';
 import ContentWrapper from '../components/ContentWrapper';
+import TagManager from '../components/TagManager';
 import NotFoundPage from './404';
 import UnauthorizedPage from './401';
 import Error from './_error';
@@ -156,6 +157,9 @@ const WrappedApp = ({ Component, pageProps }) => {
           locale: 'en_US',
           site_name: 'Biomage Cellscope',
         }}
+      />
+      <TagManager
+        environment={environment}
       />
       {mainContent(Component, pageProps)}
     </>

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -15,7 +15,7 @@ const trackingInfo = {
     containerId: 'lkIodjnO',
   },
   [Env.STAGING]: {
-    enabled: false,
+    enabled: true,
     siteId: 2,
     containerId: 'FX7UBNS6',
   },

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -12,14 +12,17 @@ const trackingInfo = {
   [Env.PRODUCTION]: {
     enabled: true,
     siteId: 1,
+    containerId: 'lkIodjnO',
   },
   [Env.STAGING]: {
     enabled: false,
     siteId: 2,
+    containerId: 'FX7UBNS6',
   },
   [Env.DEVELOPMENT]: {
     enabled: false,
     siteId: 3,
+    containerId: 'lS8ZRMXJ',
   },
 };
 
@@ -53,21 +56,6 @@ const resetTrackingId = () => {
   push(['appendToTrackingUrl', 'new_visit=1']);
 };
 
-const trackAnalysisLaunched = () => {
-  const { enabled } = getTrackingDetails(env);
-  if (enabled === false) {
-    return;
-  }
-  // Matomo events consist of four primary components which need to be configured,
-  // only two of which are required:
-  // * Category(Required) , and Form Events.
-  // * Action(Required)
-  // * Name(Optional – Recommended)
-  // * Value(Optional)
-  // See https://matomo.org/docs/event-tracking/ for more info
-  push(['trackEvent', 'data-management', 'launch-analysis']);
-};
-
 export {
-  initTracking, resetTrackingId, trackAnalysisLaunched,
+  initTracking, resetTrackingId, getTrackingDetails,
 };

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -15,7 +15,7 @@ const trackingInfo = {
     containerId: 'lkIodjnO',
   },
   [Env.STAGING]: {
-    enabled: true,
+    enabled: false,
     siteId: 2,
     containerId: 'FX7UBNS6',
   },


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1282

#### Link to staging deployment URL 

https://ui-snazzy-peach-bombay.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

Removing the previous event tracking as it will be handled by the tag manager

# Changes
### Code changes

Added `<head>` tag to initialize matomo's tag manager.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
