### PR TITLE
Add proper image paths and alt texts to the pipeline status message

### DIFF
--- a/src/components/PipelineRedirectToDataProcessing.jsx
+++ b/src/components/PipelineRedirectToDataProcessing.jsx
@@ -39,7 +39,9 @@ const PipelineRedirectToDataProcessing = ({ experimentId, pipelineStatus }) => {
     },
   };
 
-  const { status, title, subTitle } = texts[pipelineStatus];
+  const {
+    status, title, subTitle, image, alt,
+  } = texts[pipelineStatus];
 
   return (
     <Result
@@ -50,8 +52,8 @@ const PipelineRedirectToDataProcessing = ({ experimentId, pipelineStatus }) => {
         <img
           width={250}
           height={250}
-          alt='A woman fitting an oversized clipboard next to other clipboards (illustration).'
-          src='/undraw_Timeline_re_aw6g.svg'
+          alt={image}
+          src={alt}
           style={{
             display: 'block', marginLeft: 'auto', marginRight: 'auto', width: '50%',
           }}


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
Fixed invalid image and alt text being displayed to the user during QC.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
