### PR TITLE
Fix occasional double call to load marker genes

### DIFF
--- a/src/components/data-exploration/heatmap/HeatmapPlot.jsx
+++ b/src/components/data-exploration/heatmap/HeatmapPlot.jsx
@@ -45,7 +45,7 @@ const HeatmapPlot = (props) => {
 
   const cellSets = useSelector((state) => state.cellSets);
   const {
-    hierarchy, properties, hidden, loading: cellSetsLoading, updatingClustering,
+    hierarchy, properties, hidden, loading: cellSetsLoading,
   } = cellSets;
 
   const heatmapSettings = useSelector(
@@ -119,15 +119,13 @@ const HeatmapPlot = (props) => {
     expressionValue]);
 
   useEffect(() => {
-    if (updatingClustering) { return; }
-
     if (louvainClustersResolution
       && louvainClustersResolutionRef.current !== louvainClustersResolution
     ) {
       louvainClustersResolutionRef.current = louvainClustersResolution;
       dispatch(loadMarkerGenes(experimentId, louvainClustersResolution, COMPONENT_TYPE));
     }
-  }, [louvainClustersResolution, updatingClustering]);
+  }, [louvainClustersResolution]);
 
   useEffect(() => {
     setMaxCells(Math.floor(width * 0.8));

--- a/src/components/data-exploration/heatmap/HeatmapPlot.jsx
+++ b/src/components/data-exploration/heatmap/HeatmapPlot.jsx
@@ -34,7 +34,7 @@ const HeatmapPlot = (props) => {
   const [vegaData, setVegaData] = useState(null);
   const [vegaSpec, setVegaSpec] = useState(spec);
 
-  const louvainClustersRef = useRef(null);
+  const louvainClustersResolutionRef = useRef(null);
 
   const expressionData = useSelector((state) => state.genes.expression);
   const {
@@ -119,18 +119,15 @@ const HeatmapPlot = (props) => {
     expressionValue]);
 
   useEffect(() => {
-    if (cellSetsLoading || updatingClustering) { return; }
-
-    const louvainClusters = hierarchy.find((clusters) => clusters.key === 'louvain');
+    if (updatingClustering) { return; }
 
     if (louvainClustersResolution
-      && louvainClusters
-      && louvainClustersRef.current !== louvainClusters
+      && louvainClustersResolutionRef.current !== louvainClustersResolution
     ) {
-      louvainClustersRef.current = louvainClusters;
+      louvainClustersResolutionRef.current = louvainClustersResolution;
       dispatch(loadMarkerGenes(experimentId, louvainClustersResolution, COMPONENT_TYPE));
     }
-  }, [louvainClustersResolution, cellSetsLoading, updatingClustering]);
+  }, [louvainClustersResolution, updatingClustering]);
 
   useEffect(() => {
     setMaxCells(Math.floor(width * 0.8));

--- a/src/components/data-exploration/heatmap/HeatmapPlot.jsx
+++ b/src/components/data-exploration/heatmap/HeatmapPlot.jsx
@@ -45,7 +45,7 @@ const HeatmapPlot = (props) => {
 
   const cellSets = useSelector((state) => state.cellSets);
   const {
-    hierarchy, properties, hidden, loading: cellSetsLoading,
+    hierarchy, properties, hidden, loading: cellSetsLoading, updatingClustering,
   } = cellSets;
 
   const heatmapSettings = useSelector(
@@ -119,6 +119,8 @@ const HeatmapPlot = (props) => {
     expressionValue]);
 
   useEffect(() => {
+    if (cellSetsLoading || updatingClustering) { return; }
+
     const louvainClusters = hierarchy.find((clusters) => clusters.key === 'louvain');
 
     if (louvainClustersResolution
@@ -128,7 +130,7 @@ const HeatmapPlot = (props) => {
       louvainClustersRef.current = louvainClusters;
       dispatch(loadMarkerGenes(experimentId, louvainClustersResolution, COMPONENT_TYPE));
     }
-  }, [louvainClustersResolution, hierarchy]);
+  }, [louvainClustersResolution, cellSetsLoading, updatingClustering]);
 
   useEffect(() => {
     setMaxCells(Math.floor(width * 0.8));


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-ui447.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
