### PR TITLE
Turn promise factory into promise for more reliable socket pooling.

### DIFF
--- a/src/__test__/components/plots-and-tables/ViolinPlotIndex.test.jsx
+++ b/src/__test__/components/plots-and-tables/ViolinPlotIndex.test.jsx
@@ -25,6 +25,12 @@ import { expectStringInVegaCanvas } from '../../test-utils/vega-utils';
 jest.mock('localforage');
 enableFetchMocks();
 jest.mock('../../../components/plots/Header', () => () => <div />);
+jest.mock('../../../utils/socketConnection', () => ({
+  __esModule: true,
+  default: new Promise((resolve) => {
+    resolve({ emit: jest.fn(), on: jest.fn(), id: '5678' });
+  }),
+}));
 jest.mock('../../../utils/cacheRequest', () => ({
   fetchCachedWork: jest.fn().mockImplementation((expId, body) => {
     if (body.name === 'ListGenes') {

--- a/src/__test__/components/plots-and-tables/markerHeatmap.test.jsx
+++ b/src/__test__/components/plots-and-tables/markerHeatmap.test.jsx
@@ -21,10 +21,15 @@ import MarkerHeatmap from '../../../pages/experiments/[experimentId]/plots-and-t
 import * as cellSetsLoaded from '../../../redux/actions/cellSets/loadCellSets';
 import * as loadedProcessingConfig from '../../../redux/actions/experimentSettings/processingConfig/loadProcessingSettings';
 
-jest.mock('localforage');
 enableFetchMocks();
+jest.mock('localforage');
 jest.mock('../../../components/plots/Header', () => () => <div />);
-
+jest.mock('../../../utils/socketConnection', () => ({
+  __esModule: true,
+  default: new Promise((resolve) => {
+    resolve({ emit: jest.fn(), on: jest.fn(), id: '5678' });
+  }),
+}));
 jest.mock('../../../utils/cacheRequest', () => ({
   fetchCachedWork: jest.fn().mockImplementation((expId, body) => {
     if (body.name === 'ListGenes') {

--- a/src/__test__/utils/sendWork.test.js
+++ b/src/__test__/utils/sendWork.test.js
@@ -25,7 +25,7 @@ const mockOn = jest.fn(async (x, f) => {
 
 const mockEmit = jest.fn();
 const io = { emit: mockEmit, on: mockOn, id: '5678' };
-connectionPromise.mockImplementation(() => new Promise((resolve) => {
+connectionPromise.mockImplementation(new Promise((resolve) => {
   resolve(io);
 }));
 

--- a/src/components/ContentWrapper.jsx
+++ b/src/components/ContentWrapper.jsx
@@ -16,7 +16,7 @@ import {
   FolderOpenOutlined,
 } from '@ant-design/icons';
 
-import initUpdateSocket from '../utils/initUpdateSocket';
+import connectionPromise from 'utils/socketConnection';
 import experimentUpdatesHandler from '../utils/experimentUpdatesHandler';
 
 import { loadBackendStatus, discardChangedQCFilters } from '../redux/actions/experimentSettings';
@@ -75,15 +75,16 @@ const ContentWrapper = (props) => {
 
   const [changesNotAppliedModalPath, setChangesNotAppliedModalPath] = useState(null);
 
-  const updateSocket = useRef(null);
-  useEffect(() => {
+  useEffect(async () => {
     if (!experimentId) {
       return;
     }
 
     dispatch(loadBackendStatus(experimentId));
 
-    updateSocket.current = initUpdateSocket(experimentId, experimentUpdatesHandler(dispatch));
+    const io = await connectionPromise;
+    const cb = experimentUpdatesHandler(dispatch);
+    io.on(`ExperimentUpdates-${experimentId}`, (update) => cb(experimentId, update));
   }, [experimentId]);
 
   useEffect(() => {

--- a/src/components/ContentWrapper.jsx
+++ b/src/components/ContentWrapper.jsx
@@ -16,7 +16,7 @@ import {
   FolderOpenOutlined,
 } from '@ant-design/icons';
 
-import connectionPromise from 'utils/socketConnection';
+import connectionPromise from '../utils/socketConnection';
 import experimentUpdatesHandler from '../utils/experimentUpdatesHandler';
 
 import { loadBackendStatus, discardChangedQCFilters } from '../redux/actions/experimentSettings';

--- a/src/utils/sendWork.js
+++ b/src/utils/sendWork.js
@@ -10,7 +10,7 @@ const tasksForAllClients = ['ClusterCells'];
 
 const sendWork = async (experimentId, timeout, body, requestProps = {}) => {
   const requestUuid = uuidv4();
-  const io = await connectionPromise();
+  const io = await connectionPromise;
 
   // Check if we need to have a bigger timeout because the worker being down.
   const statusResponse = await fetchAPI(`/v1/experiments/${experimentId}/backendStatus`);

--- a/src/utils/socketConnection.js
+++ b/src/utils/socketConnection.js
@@ -1,36 +1,30 @@
 import socketIOClient from 'socket.io-client';
 import getApiEndpoint from './apiEndpoint';
 
-let io;
+const connectionPromise = new Promise((resolve, reject) => {
+  const io = socketIOClient(getApiEndpoint(), { transports: ['websocket'] });
 
-const connectionPromise = () => new Promise((resolve, reject) => {
-  if (io && io.connected) {
-    resolve(io);
-  } else {
-    io = socketIOClient(getApiEndpoint(), { transports: ['websocket'] });
+  io.on('connect', () => {
+    // There is a bug where `io.id` is simply not getting assigned straight away
+    // even though it should be. We don't know what causes this, so we are just waiting
+    // in the callback until an `id` property is found in the object.
+    const interval = setInterval(() => {
+      if (!io.id) {
+        return;
+      }
 
-    io.on('connect', () => {
-      // There is a bug where `io.id` is simply not getting assigned straight away
-      // even though it should be. We don't know what causes this, so we are just waiting
-      // in the callback until an `id` property is found in the object.
-      const interval = setInterval(() => {
-        if (!io.id) {
-          return;
-        }
-
-        clearInterval(interval);
-        resolve(io);
-      }, 10);
-    });
-    io.on('error', (error) => {
-      io.close();
-      reject(error);
-    });
-    io.on('connect_error', (error) => {
-      io.close();
-      reject(error);
-    });
-  }
+      clearInterval(interval);
+      resolve(io);
+    }, 10);
+  });
+  io.on('error', (error) => {
+    io.close();
+    reject(error);
+  });
+  io.on('connect_error', (error) => {
+    io.close();
+    reject(error);
+  });
 });
 
 export default connectionPromise;

--- a/src/utils/socketConnection.js
+++ b/src/utils/socketConnection.js
@@ -2,7 +2,14 @@ import socketIOClient from 'socket.io-client';
 import getApiEndpoint from './apiEndpoint';
 
 const connectionPromise = new Promise((resolve, reject) => {
-  const io = socketIOClient(getApiEndpoint(), { transports: ['websocket'] });
+  const io = socketIOClient(
+    getApiEndpoint(),
+    {
+      transports: ['websocket'],
+      reconnection: true,
+      reconnectionDelay: 500,
+    },
+  );
 
   io.on('connect', () => {
     // There is a bug where `io.id` is simply not getting assigned straight away
@@ -27,4 +34,4 @@ const connectionPromise = new Promise((resolve, reject) => {
   });
 });
 
-export default connectionPromise;
+export default () => connectionPromise;


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
`connectionPromise` is now an actual promise instead of a promise factory. This means that there is no way we can hold multiple Socket.IO connections and therefore 
# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
