### PR TITLE
Fix eternal loading screen

### DIFF
--- a/src/pages/experiments/[experimentId]/data-processing/index.jsx
+++ b/src/pages/experiments/[experimentId]/data-processing/index.jsx
@@ -58,6 +58,7 @@ const DataProcessingPage = ({ experimentId, experimentData, route }) => {
   const pipelineStatus = useSelector(
     (state) => state.backendStatus[experimentId]?.status?.pipeline,
   );
+
   const processingConfig = useSelector((state) => state.experimentSettings.processing);
   const sampleKeys = useSelector((state) => state.experimentSettings.info.sampleIds);
   const samples = useSelector((state) => state.samples);

--- a/src/redux/reducers/experimentSettings/initialState.js
+++ b/src/redux/reducers/experimentSettings/initialState.js
@@ -1,18 +1,21 @@
+const metaInitialState = {
+  loading: false,
+  completingStepError: false,
+  loadingSettingsError: false,
+  selectedConfigureEmbeddingPlot: 'cellCluster',
+  changedQCFilters: new Set(),
+};
+
 const initialState = {
   info: {
     experimentId: null,
     experimentName: null,
   },
   processing: {
-    meta: {
-      loading: false,
-      completingStepError: false,
-      loadingSettingsError: false,
-      selectedConfigureEmbeddingPlot: 'cellCluster',
-      changedQCFilters: new Set(),
-    },
+    meta: metaInitialState,
   },
   originalProcessing: {},
 };
 
+export { metaInitialState };
 export default initialState;

--- a/src/redux/reducers/experimentSettings/updateExperimentInfo.js
+++ b/src/redux/reducers/experimentSettings/updateExperimentInfo.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import produce from 'immer';
 
-import initialState from './initialState';
+import initialState, { metaInitialState } from './initialState';
 
 const updateExperimentInfo = produce((draft, action) => {
   const {
@@ -17,7 +17,7 @@ const updateExperimentInfo = produce((draft, action) => {
   draft.info.sampleIds = sampleIds;
 
   // Experiment id was updated so processing config requires reloading
-  draft.processing.meta.loading = true;
+  draft.processing = { meta: metaInitialState };
 }, initialState);
 
 export default updateExperimentInfo;


### PR DESCRIPTION
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-ui465.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
We no longer check that redux's `processing.meta.loading` is true to allow `loadProcessingConfig` to perform the api fetch, but `updateExperimentInfo` hadn't been updated to account for this change.

This caused an eternal loading screen on clicking launch analysis in data processing for experiments that had been already been run.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
