### PR TITLE
fix heatmap cellsets hide unhide

### DIFF
--- a/src/components/data-exploration/heatmap/HeatmapPlot.jsx
+++ b/src/components/data-exploration/heatmap/HeatmapPlot.jsx
@@ -46,9 +46,9 @@ const HeatmapPlot = (props) => {
   const hoverCoordinates = useRef({});
 
   const cellSets = useSelector((state) => state.cellSets);
-  const {
-    hierarchy, loading: cellSetsLoading,
-  } = cellSets;
+  const cellSetsHierarchy = useSelector((state) => state.cellSets.hierarchy);
+  const cellSetsLoading = useSelector((state) => state.cellSets.loading);
+  const cellSetsHidden = useSelector((state) => state.cellSets.hidden);
 
   const heatmapSettings = useSelector(
     (state) => state.componentConfig[COMPONENT_TYPE]?.config,
@@ -101,7 +101,7 @@ const HeatmapPlot = (props) => {
   }, [selectedGenes, loadingGenes, markerGenesLoading]);
 
   useEffect(() => {
-    if (cellSetsLoading || hierarchy.length === 0) {
+    if (cellSetsLoading || cellSetsHierarchy.length === 0) {
       return;
     }
 
@@ -128,6 +128,7 @@ const HeatmapPlot = (props) => {
     maxCells,
     markerGenesLoading,
     cellSetsLoading,
+    cellSetsHidden,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
# Background
#### Link to issue 

https://this-is-biomage.slack.com/archives/C015CHSUDRU/p1629821212019000

#### Link to staging deployment URL 

https://ui-agi-ui468.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

- Cause heatmap to re-render when cellsets are hidden

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
