### PR TITLE
Fix short barcode length

### DIFF
--- a/src/__test__/utils/upload/fileInspector.test.js
+++ b/src/__test__/utils/upload/fileInspector.test.js
@@ -81,7 +81,7 @@ describe('fileInspector', () => {
 
     readFileToBuffer
       .mockReturnValueOnce(
-        Promise.resolve(Buffer.from('ACGTTACGTGACCTGA')),
+        Promise.resolve(Buffer.from('ACGTTACGTG')),
       )
       .mockReturnValueOnce(
         Promise.resolve(Buffer.from('ENS00123456789-1')),

--- a/src/utils/upload/fileInspector.js
+++ b/src/utils/upload/fileInspector.js
@@ -26,7 +26,7 @@ const inspectFile = async (file, technology) => {
     return Verdict.INVALID_NAME;
   }
 
-  // if name is valid, inspect first 16 bytes to validate format
+  // if name is valid, inspect first 10 bytes to validate format
   let data = await readFileToBuffer(file.slice(0, 10));
 
   const isGzipped = !data.slice(0, 2).compare(GZIP_SIGNATURE);
@@ -34,7 +34,7 @@ const inspectFile = async (file, technology) => {
   if (isGzipped) {
     // if gzipped, decompress a small chunk to further validate contents
     const gunzip = new Gunzip((chunk) => {
-      data = Buffer.from(chunk.slice(0, 16));
+      data = Buffer.from(chunk.slice(0, 10));
     });
     gunzip.push(await readFileToBuffer(file.slice(0, 128)));
   }

--- a/src/utils/upload/fileInspector.js
+++ b/src/utils/upload/fileInspector.js
@@ -27,7 +27,7 @@ const inspectFile = async (file, technology) => {
   }
 
   // if name is valid, inspect first 16 bytes to validate format
-  let data = await readFileToBuffer(file.slice(0, 16));
+  let data = await readFileToBuffer(file.slice(0, 10));
 
   const isGzipped = !data.slice(0, 2).compare(GZIP_SIGNATURE);
 


### PR DESCRIPTION
# Background
#### Link to issue 

Vicky notified Agi of an error in production when uploading the 3k PBMC dataset. 

![image](https://user-images.githubusercontent.com/2862362/131113162-bc001405-91d3-40b3-b036-ed2774f4fd44.png)

The error arises because the 3k PBMC dataset barcodes consists of 14 nucleotides, while we check for 16, causing file validation to throw an error.

#### Link to staging deployment URL 

Coming soon

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

The issue is because we check for 16 bytes of the dataset.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
