### PR TITLE
[BIOMAGE-1364] - Less check for barcode

### DIFF
--- a/src/__test__/utils/upload/fileInspector.test.js
+++ b/src/__test__/utils/upload/fileInspector.test.js
@@ -81,10 +81,10 @@ describe('fileInspector', () => {
 
     readFileToBuffer
       .mockReturnValueOnce(
-        Promise.resolve(Buffer.from('ACGTTACGTGACCTGA')),
+        Promise.resolve(Buffer.from('ACGTACGTACGT-1')),
       )
       .mockReturnValueOnce(
-        Promise.resolve(Buffer.from('ENS00123456789-1')),
+        Promise.resolve(Buffer.from('ACGTACGTACGT-1\t')),
       );
 
     expect(await inspectFile(file, '10X Chromium'))

--- a/src/utils/upload/fileInspector.js
+++ b/src/utils/upload/fileInspector.js
@@ -61,7 +61,7 @@ const inspectFile = async (file, technology) => {
 
   // check barcodes file starts with a 16 digit DNA sequence
   if (file.name.startsWith('barcodes')
-      && data.toString().match(/^[ACGT]+$/)) {
+      && !data.toString().match(/\t/)) {
     return valid;
   }
 


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1364

#### Link to staging deployment URL 

https://ui-agi-ui478.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

- As discussed during sprint planning, checking for barcode file is replaecd to only check for tabs. This checks if the file does not contain more than 1 column.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [X] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
