### PR TITLE
[BIOMAGE-1382] - Fix copy to all samples

### DIFF
--- a/src/redux/reducers/experimentSettings/processingConfig/copyFilterSettingsToAllSamples.js
+++ b/src/redux/reducers/experimentSettings/processingConfig/copyFilterSettingsToAllSamples.js
@@ -8,14 +8,9 @@ const copyFilterSettingsToAllSamples = produce((draft, action) => {
   const { step, sourceSampleId, sampleIds } = action.payload;
 
   const sourceSettings = current(draft.processing[step][sourceSampleId]);
+  const samplesToReplace = [...sampleIds].filter((sampleId) => sampleId !== sourceSampleId);
 
-  // Remove sourceSampleId from the copied settings
-  const index = sampleIds.indexOf(sourceSampleId);
-  if (index > -1) {
-    sampleIds.splice(index, 1);
-  }
-
-  sampleIds.forEach((sampleIdToReplace) => {
+  samplesToReplace.forEach((sampleIdToReplace) => {
     draft.processing[step][sampleIdToReplace].auto = sourceSettings.auto;
     if (!sourceSettings.auto) {
       draft.processing[step][sampleIdToReplace]

--- a/src/redux/reducers/experimentSettings/processingConfig/copyFilterSettingsToAllSamples.js
+++ b/src/redux/reducers/experimentSettings/processingConfig/copyFilterSettingsToAllSamples.js
@@ -8,7 +8,7 @@ const copyFilterSettingsToAllSamples = produce((draft, action) => {
   const { step, sourceSampleId, sampleIds } = action.payload;
 
   const sourceSettings = current(draft.processing[step][sourceSampleId]);
-  const samplesToReplace = [...sampleIds].filter((sampleId) => sampleId !== sourceSampleId);
+  const samplesToReplace = sampleIds.filter((sampleId) => sampleId !== sourceSampleId);
 
   samplesToReplace.forEach((sampleIdToReplace) => {
     draft.processing[step][sampleIdToReplace].auto = sourceSettings.auto;


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1382

#### Link to staging deployment URL 

https://ui-agi-ui484.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

Issue is caused by doing splicing to array that is supposed to be read-only. It is fixed by creating doing a filter for a Uuid instead of a splice on index.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
