### PR TITLE
[BIOMAGE-1381] - Toggle filter disable/enable at sample level

### DIFF
--- a/src/__test__/redux/reducers/__snapshots__/experimentSettingsReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/experimentSettingsReducer.test.js.snap
@@ -66,37 +66,7 @@ Object {
 }
 `;
 
-exports[`experimentSettingsReducer Updates existing value properly 1`] = `
-Object {
-  "info": Object {
-    "experimentId": null,
-    "experimentName": null,
-  },
-  "originalProcessing": Object {
-    "configureEmbedding": Object {
-      "embeddingSettings": Object {
-        "method": "newMethod",
-      },
-    },
-  },
-  "processing": Object {
-    "configureEmbedding": Object {
-      "embeddingSettings": Object {
-        "method": "newMethod",
-      },
-    },
-    "meta": Object {
-      "changedQCFilters": Set {},
-      "completingStepError": false,
-      "loading": false,
-      "loadingSettingsError": false,
-      "selectedConfigureEmbeddingPlot": "cellCluster",
-    },
-  },
-}
-`;
-
-exports[`experimentSettingsReducer Updates sample settings properly 1`] = `
+exports[`experimentSettingsReducer Changing filter status updates sample filter settings as well 1`] = `
 Object {
   "info": Object {
     "experimentId": null,
@@ -105,11 +75,12 @@ Object {
   "originalProcessing": Object {},
   "processing": Object {
     "cellSizeDistribution": Object {
-      "enabled": true,
+      "enabled": false,
       "sample-KO": Object {
         "auto": true,
+        "enabled": false,
         "filterSettings": Object {
-          "binStep": 400,
+          "binStep": 200,
           "minCellSize": 10800,
         },
       },
@@ -118,6 +89,7 @@ Object {
       "enabled": true,
       "sample-KO": Object {
         "auto": true,
+        "enabled": true,
         "filterSettings": Object {
           "FDR": 0.1,
         },
@@ -176,6 +148,170 @@ Object {
       "enabled": true,
       "sample-KO": Object {
         "auto": true,
+        "enabled": true,
+        "filterSettings": Object {
+          "binStep": 0.05,
+          "probabilityThreshold": 0.2,
+        },
+      },
+    },
+    "meta": Object {
+      "changedQCFilters": Set {
+        "cellSizeDistribution",
+      },
+      "completingStepError": false,
+      "loading": false,
+      "loadingSettingsError": false,
+      "selectedConfigureEmbeddingPlot": "cellCluster",
+    },
+    "mitochondrialContent": Object {
+      "enabled": true,
+      "sample-KO": Object {
+        "auto": true,
+        "enabled": true,
+        "filterSettings": Object {
+          "method": "absolute_threshold",
+          "methodSettings": Object {
+            "absolute_threshold": Object {
+              "binStep": 200,
+              "maxFraction": 0.1,
+            },
+          },
+        },
+      },
+    },
+    "numGenesVsNumUmis": Object {
+      "enabled": true,
+      "sample-KO": Object {
+        "auto": true,
+        "enabled": true,
+        "filterSettings": Object {
+          "regressionType": "gam",
+          "regressionTypeSettings": Object {
+            "gam": Object {
+              "p.level": 0.00009,
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`experimentSettingsReducer Updates existing value properly 1`] = `
+Object {
+  "info": Object {
+    "experimentId": null,
+    "experimentName": null,
+  },
+  "originalProcessing": Object {
+    "configureEmbedding": Object {
+      "embeddingSettings": Object {
+        "method": "newMethod",
+      },
+    },
+  },
+  "processing": Object {
+    "configureEmbedding": Object {
+      "embeddingSettings": Object {
+        "method": "newMethod",
+      },
+    },
+    "meta": Object {
+      "changedQCFilters": Set {},
+      "completingStepError": false,
+      "loading": false,
+      "loadingSettingsError": false,
+      "selectedConfigureEmbeddingPlot": "cellCluster",
+    },
+  },
+}
+`;
+
+exports[`experimentSettingsReducer Updates sample settings properly 1`] = `
+Object {
+  "info": Object {
+    "experimentId": null,
+    "experimentName": null,
+  },
+  "originalProcessing": Object {},
+  "processing": Object {
+    "cellSizeDistribution": Object {
+      "enabled": true,
+      "sample-KO": Object {
+        "auto": true,
+        "enabled": true,
+        "filterSettings": Object {
+          "binStep": 400,
+          "minCellSize": 10800,
+        },
+      },
+    },
+    "classifier": Object {
+      "enabled": true,
+      "sample-KO": Object {
+        "auto": true,
+        "enabled": true,
+        "filterSettings": Object {
+          "FDR": 0.1,
+        },
+      },
+    },
+    "configureEmbedding": Object {
+      "clusteringSettings": Object {
+        "method": "louvain",
+        "methodSettings": Object {
+          "louvain": Object {
+            "resolution": 0.5,
+          },
+        },
+      },
+      "embeddingSettings": Object {
+        "method": "umap",
+        "methodSettings": Object {
+          "tsne": Object {
+            "learningRate": 200,
+            "perplexity": 30,
+          },
+          "umap": Object {
+            "distanceMetric": "euclidean",
+            "minimumDistance": 0.1,
+          },
+        },
+      },
+      "enabled": true,
+    },
+    "dataIntegration": Object {
+      "dataIntegration": Object {
+        "method": "seuratv4",
+        "methodSettings": Object {
+          "fastmnn": Object {
+            "normalisation": "logNormalize",
+            "numGenes": 2000,
+          },
+          "seuratv4": Object {
+            "normalisation": "logNormalize",
+            "numGenes": 2000,
+          },
+          "unisample": Object {
+            "normalisation": "logNormalize",
+            "numGenes": 2000,
+          },
+        },
+      },
+      "dimensionalityReduction": Object {
+        "excludeGeneCategories": Array [],
+        "method": "rpca",
+        "numPCs": 30,
+      },
+      "enabled": true,
+    },
+    "doubletScores": Object {
+      "enabled": true,
+      "sample-KO": Object {
+        "auto": true,
+        "enabled": true,
         "filterSettings": Object {
           "binStep": 0.05,
           "probabilityThreshold": 0.2,
@@ -193,6 +329,7 @@ Object {
       "enabled": true,
       "sample-KO": Object {
         "auto": true,
+        "enabled": true,
         "filterSettings": Object {
           "method": "absolute_threshold",
           "methodSettings": Object {
@@ -208,6 +345,7 @@ Object {
       "enabled": true,
       "sample-KO": Object {
         "auto": true,
+        "enabled": true,
         "filterSettings": Object {
           "regressionType": "gam",
           "regressionTypeSettings": Object {

--- a/src/__test__/redux/reducers/experimentSettingsReducer.test.js
+++ b/src/__test__/redux/reducers/experimentSettingsReducer.test.js
@@ -1,3 +1,4 @@
+import { enableMapSet } from 'immer';
 import experimentSettingsReducer from '../../../redux/reducers/experimentSettings';
 import initialState from '../../../redux/reducers/experimentSettings/initialState';
 import generateExperimentSettingsMock from '../../test-utils/experimentSettings.mock';
@@ -7,9 +8,12 @@ import {
   EXPERIMENT_SETTINGS_PROCESSING_CONFIG_LOADED,
   EXPERIMENT_SETTINGS_PROCESSING_ERROR,
   EXPERIMENT_SETTINGS_SAMPLE_FILTER_UPDATE,
+  EXPERIMENT_SETTINGS_SET_QC_STEP_ENABLED,
 } from '../../../redux/actionTypes/experimentSettings';
 
 import errorTypes from '../../../redux/actions/experimentSettings/errorTypes';
+
+enableMapSet();
 
 const initialExperimentState = generateExperimentSettingsMock(['sample-KO']);
 
@@ -108,6 +112,7 @@ describe('experimentSettingsReducer', () => {
       enabled: true,
       'sample-KO': {
         auto: true,
+        enabled: true,
         filterSettings: {
           minCellSize: 10800,
           binStep: 400,
@@ -116,6 +121,36 @@ describe('experimentSettingsReducer', () => {
     };
 
     // New entry is created for sample-KO with the new binStep while default value isn't changed
+    expect(newState.processing.cellSizeDistribution).toEqual(expectedCellSizeDistribution);
+
+    // Nothing else changes
+    expect(newState).toMatchSnapshot();
+  });
+
+  it('Changing filter status updates sample filter settings as well', () => {
+    const newState = experimentSettingsReducer(initialExperimentState,
+      {
+        type: EXPERIMENT_SETTINGS_SET_QC_STEP_ENABLED,
+        payload:
+        {
+          step: 'cellSizeDistribution',
+          enabled: false,
+        },
+      });
+
+    const expectedCellSizeDistribution = {
+      enabled: false,
+      'sample-KO': {
+        auto: true,
+        enabled: false,
+        filterSettings: {
+          minCellSize: 10800,
+          binStep: 200,
+        },
+      },
+    };
+
+    // New entry is created for sample-KO with the new enabled changed to equal that in payload
     expect(newState.processing.cellSizeDistribution).toEqual(expectedCellSizeDistribution);
 
     // Nothing else changes

--- a/src/__test__/redux/reducers/experimentSettingsReducer.test.js
+++ b/src/__test__/redux/reducers/experimentSettingsReducer.test.js
@@ -127,7 +127,7 @@ describe('experimentSettingsReducer', () => {
     expect(newState).toMatchSnapshot();
   });
 
-  it('Changing filter status updates sample filter settings as well', () => {
+  it('Changing filter enabled property updates sample filter enabled property as well', () => {
     const newState = experimentSettingsReducer(initialExperimentState,
       {
         type: EXPERIMENT_SETTINGS_SET_QC_STEP_ENABLED,

--- a/src/__test__/test-utils/experimentSettings.mock.js
+++ b/src/__test__/test-utils/experimentSettings.mock.js
@@ -18,6 +18,7 @@ const generateProcessingConfigMock = (sampleIds) => ({
     enabled: true,
     ...sampleifiedConfig(sampleIds, {
       auto: true,
+      enabled: true,
       filterSettings: {
         minCellSize: 10800,
         binStep: 200,
@@ -28,6 +29,7 @@ const generateProcessingConfigMock = (sampleIds) => ({
     enabled: true,
     ...sampleifiedConfig(sampleIds, {
       auto: true,
+      enabled: true,
       filterSettings: {
         method: 'absolute_threshold',
         methodSettings: {
@@ -43,6 +45,7 @@ const generateProcessingConfigMock = (sampleIds) => ({
     enabled: true,
     ...sampleifiedConfig(sampleIds, {
       auto: true,
+      enabled: true,
       filterSettings: {
         FDR: 0.1,
       },
@@ -52,6 +55,7 @@ const generateProcessingConfigMock = (sampleIds) => ({
     enabled: true,
     ...sampleifiedConfig(sampleIds, {
       auto: true,
+      enabled: true,
       filterSettings: {
         regressionType: 'gam',
         regressionTypeSettings: {
@@ -66,6 +70,7 @@ const generateProcessingConfigMock = (sampleIds) => ({
     enabled: true,
     ...sampleifiedConfig(sampleIds, {
       auto: true,
+      enabled: true,
       filterSettings: {
         probabilityThreshold: 0.2,
         binStep: 0.05,

--- a/src/redux/reducers/experimentSettings/processingConfig/setQCStepEnabled.js
+++ b/src/redux/reducers/experimentSettings/processingConfig/setQCStepEnabled.js
@@ -6,7 +6,16 @@ import initialState from '../initialState';
 const setQCStepEnabled = produce((draft, action) => {
   const { step, enabled } = action.payload;
 
+  const {
+    enabled: oldEnable, auto, filterSettings, ...sampleIds
+  } = draft.processing[step];
+
   draft.processing[step].enabled = enabled;
+
+  // Filter is applied per samples in the pipeline
+  Object.keys(sampleIds).forEach((sampleId) => {
+    draft.processing[step][sampleId].enabled = enabled;
+  });
 
   draft.processing.meta.changedQCFilters.add(step);
 }, initialState);


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1381

#### Link to staging deployment URL 

https://ui-agi-ui485.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

The error appears because the status of the filter (enabled/disabled) is saved at the root of the filter, but not propagated down to samples level. Meanwhile, in the API, the configuration object is stripped of root-level properties so that only sample objects are passed to the pipeline (https://github.com/biomage-ltd/api/blob/master/src/api/general-services/pipeline-manage/index.js#L197). Therefore, there are 2 ways to approach this problem : 

- in the API : Copy the root level enabled/disabled settings to samples during config preparation before passing to pipeline.
- in the UI: Update sample-level enabled/disabled settings.

The option in the UI provides more flexibility, if we decide to modify this behaviour later on (e.g. allow sample-level enable/disable)

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [x] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
