### PR TITLE
Add indicator classnames

### DIFF
--- a/src/components/ContentWrapper.jsx
+++ b/src/components/ContentWrapper.jsx
@@ -31,6 +31,7 @@ import ChangesNotAppliedModal from './ChangesNotAppliedModal';
 
 import Error from '../pages/_error';
 import pipelineStatus from '../utils/pipelineStatusValues';
+import integrationTestIds from '../utils/integrationTestIds';
 
 import { initialExperimentBackendStatus } from '../redux/reducers/backendStatus/initialState';
 
@@ -70,7 +71,6 @@ const ContentWrapper = (props) => {
   const changedQCFilters = useSelector(
     (state) => state.experimentSettings.processing.meta.changedQCFilters,
   );
-
 
   // This is used to prevent a race condition where the page would start loading immediately
   // when the backend status was previously loaded. In that case, `backendLoading` is `false`
@@ -339,7 +339,7 @@ const ContentWrapper = (props) => {
           {!collapsed && <BigLogo />}
           {collapsed && <SmallLogo />}
           <Menu
-            data-test-id='navigation-menu'
+            data-test-id={integrationTestIds.id.NAVIGATION_MENU}
             theme='dark'
             selectedKeys={
               menuLinks

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,6 +9,7 @@ import UserButton from './UserButton';
 import FeedbackButton from './FeedbackButton';
 import ReferralButton from './ReferralButton';
 import itemRender from '../utils/renderBreadcrumbLinks';
+import integrationTestIds from '../utils/integrationTestIds';
 
 const Header = (props) => {
   const {
@@ -64,7 +65,7 @@ const Header = (props) => {
       />
 
       <PageHeader
-        className='data-test-page-header'
+        className={integrationTestIds.class.PAGE_HEADER}
         title={title}
         style={{ width: '100%', paddingTop: '12px', paddingBottom: '6px' }}
         breadcrumb={{ routes: buildRoutes(route), itemRender }}

--- a/src/components/data-management/AnalysisModal.jsx
+++ b/src/components/data-management/AnalysisModal.jsx
@@ -14,6 +14,7 @@ import { ClipLoader } from 'react-spinners';
 import EditableField from '../EditableField';
 import { updateExperiment, saveExperiment } from '../../redux/actions/experiments';
 import validateInputs, { rules } from '../../utils/validateInputs';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const { Title } = Typography;
 
@@ -69,7 +70,7 @@ const NewExperimentModal = (props) => {
           <List.Item
             key={`${experiment.id}`}
             extra={(
-              <Row type='flex' align='middle' data-test-class='launch-analysis-item'>
+              <Row type='flex' align='middle' data-test-class={integrationTestIds.class.LAUNCH_ANALYSIS_ITEM}>
                 <Col>
                   <Button
                     type='primary'

--- a/src/components/data-management/NewProjectModal.jsx
+++ b/src/components/data-management/NewProjectModal.jsx
@@ -6,6 +6,7 @@ import {
 } from 'antd';
 import { ClipLoader } from 'react-spinners';
 import validateInputs, { rules } from '../../utils/validateInputs';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const { Text, Title, Paragraph } = Typography;
 const { TextArea } = Input;
@@ -55,12 +56,12 @@ const NewProjectModal = (props) => {
 
   return (
     <Modal
-      className='data-test-new-project-modal'
+      className={integrationTestIds.class.NEW_PROJECT_MODAL}
       title='Create a new project'
       visible={visible}
       footer={(
         <Button
-          data-test-id='confirm-create-new-project'
+          data-test-id={integrationTestIds.id.CONFIRM_CREATE_NEW_PROJECT}
           type='primary'
           key='create'
           block
@@ -114,7 +115,7 @@ const NewProjectModal = (props) => {
               name='requiredMark'
             >
               <Input
-                data-test-id='project-name'
+                data-test-id={integrationTestIds.id.PROJECT_NAME}
                 onChange={(e) => {
                   setProjectName(e.target.value.trim());
                 }}
@@ -134,7 +135,7 @@ const NewProjectModal = (props) => {
               label='Project description'
             >
               <TextArea
-                data-test-id='project-description'
+                data-test-id={integrationTestIds.id.PROJECT_DESCRIPTION}
                 onChange={(e) => { setProjectDescription(e.target.value); }}
                 placeholder='Type description'
                 autoSize={{ minRows: 3, maxRows: 5 }}

--- a/src/components/data-management/ProjectDeleteModal.jsx
+++ b/src/components/data-management/ProjectDeleteModal.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Modal, Button, Input, Space, Typography, Form, Alert,
 } from 'antd';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const { Text, Paragraph } = Typography;
 
@@ -16,7 +17,7 @@ const ProjectDeleteModal = (props) => {
 
   return (
     <Modal
-      className='data-test-delete-project-modal'
+      className={integrationTestIds.class.DELETE_PROJECT_MODAL}
       title='Confirm delete'
       visible={visible}
       footer={(

--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -42,6 +42,7 @@ import { metadataNameToKey, metadataKeyToName, temporaryMetadataKey } from '../.
 import '../../utils/css/data-management.css';
 import runGem2s from '../../redux/actions/pipeline/runGem2s';
 import ProjectMenu from './ProjectMenu';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const { Text } = Typography;
 
@@ -259,7 +260,7 @@ const ProjectDetails = ({ width, height }) => {
       render: () => <DragHandle />,
     },
     {
-      className: 'data-test-class-sample-cell',
+      className: `${integrationTestIds.class.SAMPLE_CELL}`,
       index: 1,
       key: 'sample',
       title: 'Sample',

--- a/src/components/data-management/ProjectMenu.jsx
+++ b/src/components/data-management/ProjectMenu.jsx
@@ -9,6 +9,7 @@ import {
 } from '../../redux/actions/projects'; import DownloadData from './DownloadData';
 import fileUploadSpecifications from '../../utils/upload/fileUploadSpecifications';
 import UploadStatus from '../../utils/upload/UploadStatus';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -81,7 +82,7 @@ const ProjectMenu = (props) => {
             activeProjectUuid={activeProjectUuid}
           />
           <Button
-            data-test-id='launch-analysis-button'
+            data-test-id={integrationTestIds.id.LAUNCH_ANALYSIS_BUTTON}
             type='primary'
             disabled={!canLaunchAnalysis()}
             onClick={() => openAnalysisModal()}

--- a/src/components/data-management/ProjectsListContainer.jsx
+++ b/src/components/data-management/ProjectsListContainer.jsx
@@ -13,6 +13,7 @@ import ProjectDeleteModal from './ProjectDeleteModal';
 import { setActiveProject, updateProject, deleteProject as deleteProjectAction } from '../../redux/actions/projects';
 import PrettyTime from '../PrettyTime';
 import validateInputs, { rules } from '../../utils/validateInputs';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const ProjectsListContainer = (props) => {
   const { height } = props;
@@ -69,7 +70,7 @@ const ProjectsListContainer = (props) => {
         {
           projects.ids.map((uuid) => (
             <Card
-              data-test-class='project-card'
+              data-test-class={integrationTestIds.class.PROJECT_CARD}
               key={uuid}
               type='primary'
               style={activeProjectUuid === uuid ? activeProjectStyle : { cursor: 'pointer' }}

--- a/src/components/data-processing/StepsIndicator.jsx
+++ b/src/components/data-processing/StepsIndicator.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const StepsIndicator = (props) => {
   const { allSteps, completedSteps, currentStep } = props;
@@ -18,12 +19,12 @@ const StepsIndicator = (props) => {
     >
       {allSteps.map((step, index) => {
         let color = colors.completed;
-        let dataTestClass = 'qc-step-completed';
+        let dataTestClass = dataTestClass = integrationTestIds.class.QC_STEP_COMPLETED;
         if (index === currentStep) {
           color = colors.currentStep;
         } else if (index > completedSteps - 1) {
           color = colors.notCompleted;
-          dataTestClass = 'qc-step-not-completed';
+          dataTestClass = integrationTestIds.class.QC_STEP_NOT_COMPLETED;
         }
         return (
           <svg width='18' height='10' data-test-class={dataTestClass}>

--- a/src/components/data-processing/StepsIndicator.jsx
+++ b/src/components/data-processing/StepsIndicator.jsx
@@ -9,11 +9,6 @@ const StepsIndicator = (props) => {
     completed: '#009930', // blue
   };
 
-  const testClasses = {
-    notCompleted: 'qc-step-not-completed',
-    completed: 'qc-step-completed',
-  };
-
   return (
     <div
       role='progressbar'
@@ -23,15 +18,15 @@ const StepsIndicator = (props) => {
     >
       {allSteps.map((step, index) => {
         let color = colors.completed;
-        let testClass = testClasses.completed;
+        let dataTestClass = 'qc-step-completed';
         if (index === currentStep) {
           color = colors.currentStep;
         } else if (index > completedSteps - 1) {
           color = colors.notCompleted;
-          testClass = testClasses.notCompleted;
+          dataTestClass = 'qc-step-not-completed';
         }
         return (
-          <svg width='18' height='10' data-test-class={testClass}>
+          <svg width='18' height='10' data-test-class={dataTestClass}>
             <rect width='16' height='8' style={{ fill: color }} />
           </svg>
         );

--- a/src/components/data-processing/StepsIndicator.jsx
+++ b/src/components/data-processing/StepsIndicator.jsx
@@ -19,7 +19,7 @@ const StepsIndicator = (props) => {
     >
       {allSteps.map((step, index) => {
         let color = colors.completed;
-        let dataTestClass = dataTestClass = integrationTestIds.class.QC_STEP_COMPLETED;
+        let dataTestClass = integrationTestIds.class.QC_STEP_COMPLETED;
         if (index === currentStep) {
           color = colors.currentStep;
         } else if (index > completedSteps - 1) {

--- a/src/components/data-processing/StepsIndicator.jsx
+++ b/src/components/data-processing/StepsIndicator.jsx
@@ -8,6 +8,12 @@ const StepsIndicator = (props) => {
     currentStep: '#ff6f00', // orange
     completed: '#009930', // blue
   };
+
+  const testClasses = {
+    notCompleted: 'qc-step-not-completed',
+    completed: 'qc-step-completed',
+  };
+
   return (
     <div
       role='progressbar'
@@ -17,13 +23,15 @@ const StepsIndicator = (props) => {
     >
       {allSteps.map((step, index) => {
         let color = colors.completed;
+        let testClass = testClasses.completed;
         if (index === currentStep) {
           color = colors.currentStep;
         } else if (index > completedSteps - 1) {
           color = colors.notCompleted;
+          testClass = testClasses.notCompleted;
         }
         return (
-          <svg width='18' height='10'>
+          <svg width='18' height='10' data-test-class={testClass}>
             <rect width='16' height='8' style={{ fill: color }} />
           </svg>
         );

--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -18,6 +18,7 @@ import ProjectDetails from '../../components/data-management/ProjectDetails';
 import LoadingModal from '../../components/LoadingModal';
 import { loadProcessingSettings } from '../../redux/actions/experimentSettings';
 import loadBackendStatus from '../../redux/actions/backendStatus/loadBackendStatus';
+import integrationTestIds from '../../utils/integrationTestIds';
 
 const DataManagementPage = ({ route }) => {
   const dispatch = useDispatch();
@@ -127,7 +128,7 @@ const DataManagementPage = ({ route }) => {
           style={{ width: '100%' }}
         >
           <Button
-            data-test-id='create-new-project-button'
+            data-test-id={integrationTestIds.id.CREATE_NEW_PROJECT_BUTTON}
             type='primary'
             block
             onClick={() => setNewProjectModalVisible(true)}

--- a/src/utils/integrationTestIds.js
+++ b/src/utils/integrationTestIds.js
@@ -1,0 +1,26 @@
+// File containing data-test id and class values for use in Cypress tests.
+
+const dataTestId = {
+  NAVIGATION_MENU: 'navigation-menu',
+  CONFIRM_CREATE_NEW_PROJECT: 'confirm-create-new-project',
+  CREATE_NEW_PROJECT_BUTTON: 'create-new-project-button',
+  PROJECT_NAME: 'project-name',
+  PROJECT_DESCRIPTION: 'project-description',
+  LAUNCH_ANALYSIS_BUTTON: 'launch-analysis-button',
+};
+
+const dataTestClass = {
+  PAGE_HEADER: 'data-test-page-header',
+  LAUNCH_ANALYSIS_ITEM: 'data-test-launch-analysis-item',
+  NEW_PROJECT_MODAL: 'data-test-new-project-modal',
+  DELETE_PROJECT_MODAL: 'data-test-delete-project-modal',
+  SAMPLE_CELL: 'data-test-sample-cell',
+  PROJECT_CARD: 'data-test-project-card',
+  QC_STEP_COMPLETED: 'data-test-qc-step-completed',
+  QC_STEP_NOT_COMPLETED: 'data-test-qc-step-not-completed',
+};
+
+export default {
+  id: dataTestId,
+  class: dataTestClass,
+};


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

Add class names to the status indicator icons so that tests can follow the progress of QC.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
