### PR TITLE
Fix expeirments redux on sample creation

### DIFF
--- a/src/__test__/redux/actions/samples/createSample.test.js
+++ b/src/__test__/redux/actions/samples/createSample.test.js
@@ -9,12 +9,12 @@ import initialProjectState, { projectTemplate } from 'redux/reducers/projects/in
 import initialExperimentState, { experimentTemplate } from 'redux/reducers/experiments/initialState';
 
 import { SAMPLES_CREATE, SAMPLES_SAVING, SAMPLES_ERROR } from 'redux/actionTypes/samples';
-import updateExperiment from 'redux/actions/experiments/updateExperiment';
+import saveExperiment from 'redux/actions/experiments/saveExperiment';
 
 import pushNotificationMessage from 'utils/pushNotificationMessage';
 
-jest.mock('redux/actions/experiments/updateExperiment');
-updateExperiment.mockImplementation(() => async () => { });
+jest.mock('redux/actions/experiments/saveExperiment');
+saveExperiment.mockImplementation(() => async () => { });
 
 jest.mock('utils/pushNotificationMessage');
 pushNotificationMessage.mockImplementation(() => async () => { });
@@ -96,7 +96,7 @@ describe('createSample action', () => {
     expect(actions[1].type).toEqual(SAMPLES_CREATE);
 
     // Calls update experiment on success of fetch
-    expect(updateExperiment).toHaveBeenCalledWith(experimentId, { sampleIds: [sampleUuid] });
+    expect(saveExperiment).toHaveBeenCalledWith(experimentId);
   });
 
   it('Shows error message when there was a fetch error', async () => {

--- a/src/__test__/redux/reducers/__snapshots__/experimentsReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/experimentsReducer.test.js.snap
@@ -1,5 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`experimentsReducer Adds new sampleId when sample is created 1`] = `
+Object {
+  "experiment-1": Object {
+    "createdDate": "01-01-2021",
+    "description": "this is a test description",
+    "id": "experiment-1",
+    "lastViewed": "01-01-2021",
+    "meta": Object {
+      "organism": null,
+      "type": "10x",
+    },
+    "name": "experiment 1",
+    "projectUuid": "project-1",
+    "sampleIds": Array [
+      "testSampleId",
+    ],
+  },
+  "ids": Array [
+    "experiment-1",
+  ],
+  "meta": Object {
+    "error": false,
+    "loading": false,
+    "saving": false,
+  },
+}
+`;
+
+exports[`experimentsReducer Adds new sampleId when sample is created and we already have one sample 1`] = `
+Object {
+  "experiment-1": Object {
+    "createdDate": "01-01-2021",
+    "description": "this is a test description",
+    "id": "experiment-1",
+    "lastViewed": "01-01-2021",
+    "meta": Object {
+      "organism": null,
+      "type": "10x",
+    },
+    "name": "experiment 1",
+    "projectUuid": "project-1",
+    "sampleIds": Array [
+      "testSampleId",
+      "testAnotherSampleId",
+    ],
+  },
+  "ids": Array [
+    "experiment-1",
+  ],
+  "meta": Object {
+    "error": false,
+    "loading": false,
+    "saving": false,
+  },
+}
+`;
+
 exports[`experimentsReducer Deletes an experiment correctly 1`] = `
 Object {
   "experiment-1": Object {

--- a/src/__test__/redux/reducers/experimentsReducer.test.js
+++ b/src/__test__/redux/reducers/experimentsReducer.test.js
@@ -1,5 +1,7 @@
-import experimentsReducer from '../../../redux/reducers/experiments';
-import initialState, { experimentTemplate } from '../../../redux/reducers/experiments/initialState';
+import { SAMPLES_CREATE } from 'redux/actionTypes/samples';
+import experimentsReducer from 'redux/reducers/experiments';
+import initialState, { experimentTemplate } from 'redux/reducers/experiments/initialState';
+import { sampleTemplate } from 'redux/reducers/samples/initialState';
 
 import {
   EXPERIMENTS_CREATED,
@@ -69,6 +71,12 @@ describe('experimentsReducer', () => {
     meta: experimentTemplate.meta,
   };
 
+  const sampleId = 'testSampleId';
+  const experiment1WithSample = {
+    ...experiment1,
+    sampleIds: [sampleId],
+  };
+
   const updatedExperiment = {
     ...experiment1,
     name: 'updated name',
@@ -86,6 +94,20 @@ describe('experimentsReducer', () => {
     ids: [experimentId1, experimentId2],
     [experimentId1]: experiment1,
     [experimentId2]: experiment2,
+  };
+
+  const oneExperimentWithSampleState = {
+    ...initialState,
+    ids: [experimentId1],
+    [experimentId1]: experiment1WithSample,
+  };
+
+  const sample = {
+    ...sampleTemplate,
+    name: 'test sample',
+    uuid: sampleId,
+    createdDate: '2021-01-01T14:48:00.000Z',
+    lastModified: '2021-01-01T14:48:00.000Z',
   };
 
   it('Reduces identical state on unknown action', () => expect(
@@ -200,6 +222,40 @@ describe('experimentsReducer', () => {
     expect(newState.ids).toEqual([experiment1.id]);
     expect(newState[experiment1.id]).toBe(undefined);
     expect(newState).toEqual(invalidExperimentState);
+    expect(newState).toMatchSnapshot();
+  });
+
+  it('Adds new sampleId when sample is created', () => {
+    const newState = experimentsReducer(oneExperimentState, {
+      type: SAMPLES_CREATE,
+      payload: {
+        experimentId: experiment1.id,
+        sample,
+      },
+    });
+
+    expect(newState[experiment1.id].sampleIds).toEqual([sample.uuid]);
+    expect(newState).toMatchSnapshot();
+  });
+
+  it('Adds new sampleId when sample is created and we already have one sample', () => {
+    const anotherSample = {
+      ...sampleTemplate,
+      name: 'another test sample',
+      uuid: 'testAnotherSampleId',
+      createdDate: '2021-01-01T14:48:00.000Z',
+      lastModified: '2021-01-01T14:48:00.000Z',
+    };
+
+    const newState = experimentsReducer(oneExperimentWithSampleState, {
+      type: SAMPLES_CREATE,
+      payload: {
+        experimentId: experiment1.id,
+        sample: anotherSample,
+      },
+    });
+
+    expect(newState[experiment1.id].sampleIds).toEqual([sampleId, anotherSample.uuid]);
     expect(newState).toMatchSnapshot();
   });
 });

--- a/src/redux/actions/samples/createSample.js
+++ b/src/redux/actions/samples/createSample.js
@@ -14,7 +14,7 @@ import pushNotificationMessage from 'utils/pushNotificationMessage';
 import { isServerError, throwIfRequestFailed } from 'utils/fetchErrors';
 
 import { sampleTemplate } from 'redux/reducers/samples/initialState';
-import updateExperiment from 'redux/actions/experiments/updateExperiment';
+import saveExperiment from 'redux/actions/experiments/saveExperiment';
 
 const createSample = (
   projectUuid,
@@ -26,7 +26,6 @@ const createSample = (
   const createdDate = moment().toISOString();
 
   const experimentId = project.experiments[0];
-  const experiment = getState().experiments[experimentId];
 
   const newSampleUuid = uuidv4();
 
@@ -69,15 +68,10 @@ const createSample = (
 
     dispatch({
       type: SAMPLES_CREATE,
-      payload: { sample: newSample },
+      payload: { sample: newSample, experimentId },
     });
 
-    dispatch(
-      updateExperiment(
-        experimentId,
-        { sampleIds: [...experiment.sampleIds, newSampleUuid] },
-      ),
-    );
+    dispatch(saveExperiment(experimentId));
   } catch (e) {
     let { message } = e;
     if (!isServerError(e)) {

--- a/src/redux/reducers/experiments/index.js
+++ b/src/redux/reducers/experiments/index.js
@@ -9,6 +9,11 @@ import {
   EXPERIMENTS_SAVING,
   EXPERIMENTS_DELETED,
 } from '../../actionTypes/experiments';
+
+import {
+  SAMPLES_CREATE,
+} from '../../actionTypes/samples';
+
 import experimentsCreate from './experimentsCreate';
 import experimentsUpdate from './experimentsUpdate';
 import experimentsDelete from './experimentsDelete';
@@ -17,6 +22,7 @@ import experimentsLoaded from './experimentsLoaded';
 import experimentsError from './experimentsError';
 import experimentsSaving from './experimentsSaving';
 import exprimentsSaved from './experimentsSaved';
+import samplesCreate from './samplesCreate';
 
 const experimentsReducer = (state = initialState, action) => {
   switch (action.type) {
@@ -50,6 +56,10 @@ const experimentsReducer = (state = initialState, action) => {
 
     case EXPERIMENTS_SAVED: {
       return exprimentsSaved(state, action);
+    }
+
+    case SAMPLES_CREATE: {
+      return samplesCreate(state, action);
     }
 
     default: {

--- a/src/redux/reducers/experiments/samplesCreate.js
+++ b/src/redux/reducers/experiments/samplesCreate.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-param-reassign */
+import produce from 'immer';
+
+import initialState from './initialState';
+
+const samplesCreate = produce((draft, action) => {
+  const { sample, experimentId } = action.payload;
+
+  const { uuid: newSampleUuid } = sample;
+
+  draft[experimentId].sampleIds.push(newSampleUuid);
+}, initialState);
+
+export default samplesCreate;


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-ui530.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
