### PR TITLE
[BIOMAGE-1543] added check for null-key samples

### DIFF
--- a/src/__test__/utils/cellSets/getSampleCells.test.js
+++ b/src/__test__/utils/cellSets/getSampleCells.test.js
@@ -1,9 +1,9 @@
-import { getSampleCells } from 'utils/cellSets';
-
 import {
   createHierarchyFromTree,
   createPropertiesFromTree,
 } from 'redux/reducers/cellSets/helpers';
+
+import { getSampleCells } from 'utils/cellSets';
 
 const mockCellSet = require('__test__/data/cell_sets.json');
 
@@ -16,7 +16,7 @@ const sampleKey = 'louvain-0';
 const numCells = cellSets.properties[sampleKey].cellIds.size;
 
 describe('Get sample cells', () => {
-  it('Returns all ids of all cells', () => {
+  it('returns all ids of all cells', () => {
     const allCellIds = getSampleCells(cellSets, 'louvain-0');
     expect(allCellIds.length).toEqual(numCells);
 
@@ -28,12 +28,13 @@ describe('Get sample cells', () => {
     `);
   });
 
-  it('Throws an error if cellSets does not exist', () => {
+  it('does not throw an error if cellSets does not exist', () => {
     const emptyCellSets = {
       properties: {},
       hierarchy: [],
     };
 
-    expect(() => { getSampleCells(emptyCellSets, 'louvain-0'); }).toThrow();
+    expect(() => { getSampleCells(emptyCellSets, 'louvain-0'); }).not.toThrow();
+    expect(getSampleCells(emptyCellSets, 'louvain-0')).toEqual([]);
   });
 });

--- a/src/utils/cellSets/getSampleCells.js
+++ b/src/utils/cellSets/getSampleCells.js
@@ -1,4 +1,8 @@
 const getSampleCells = (cellSets, sampleKey) => {
+  if (!(sampleKey in cellSets.properties)) {
+    return [];
+  }
+
   const cellIds = Array.from(cellSets.properties[sampleKey].cellIds);
 
   return cellIds.map((cellId) => ({


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1543
#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Code updates
Have best practices and ongoing refactors being observed in this PR

- [ ] Migrated any selector / reducer used to the new format
- [ ] Validated that current unit tests work as expected and are enough

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
