### PR TITLE
Disable browser cache in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ Alternatively, you can use `npm run analyze:server` or `npm run analyze:client` 
 bundle sizes for just server-side rendered and client-side scripts.
 
 The script will produce HTML artifacts that will open in your default browser as a Voronoi treemap.
+
+### Browser cache
+
+Browser cache enabled by default in production environment. This can be disabled by adding the entry 
+"disableCache" to "true" via the console using the command:
+
+    localStorage.set("disableCache", "true")
+
+Browser cache makes it hard to develop as it can hide changes from the backend, so cache is disabled 
+by default in development.

--- a/README.md
+++ b/README.md
@@ -89,5 +89,4 @@ Browser cache enabled by default in production environment. This can be disabled
 
     localStorage.set("disableCache", "true")
 
-Browser cache makes it hard to develop as it can hide changes from the backend, so cache is disabled 
-by default in development.
+Browser cache makes it hard to develop as it can hide changes from the backend, so cache is disabled by default in development. This can be changed by modifying `disableCache` in `localStorage` manually .

--- a/src/__test__/utils/work/fetchWork.mock.js
+++ b/src/__test__/utils/work/fetchWork.mock.js
@@ -135,9 +135,9 @@ const mockSeekWorkResponseModule = {
   ),
 };
 
-const mockReduxState = (experimentId) => () => ({
+const mockReduxState = (experimentId, environment = 'testing') => () => ({
   networkResources: {
-    environment: 'testing',
+    environment,
   },
   backendStatus: {
     [experimentId]: {

--- a/src/__test__/utils/work/fetchWork.test.js
+++ b/src/__test__/utils/work/fetchWork.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
-import { fetchWork } from '../../../utils/work/fetchWork';
+import { fetchWork } from 'utils/work/fetchWork';
 import '__test__/test-utils/setupTests';
+import Environment from 'utils/environment';
 
 const {
   mockData, mockCacheKeyMappings, mockCacheGet, mockCacheSet, mockSeekFromAPI, mockReduxState,
@@ -42,7 +43,7 @@ describe('fetchWork', () => {
   });
 
   it('does not change ETag if caching is enabled', async () => {
-    Storage.prototype.getItem = jest.fn((key) => (key === 'disableCache' ? false : null));
+    Storage.prototype.getItem = jest.fn((key) => (key === 'disableCache' ? 'false' : null));
 
     await fetchWork(
       experimentId,
@@ -57,7 +58,7 @@ describe('fetchWork', () => {
   });
 
   it('changes ETag if caching is disabled', async () => {
-    Storage.prototype.getItem = jest.fn((key) => (key === 'disableCache' ? true : null));
+    Storage.prototype.getItem = jest.fn((key) => (key === 'disableCache' ? 'true' : null));
 
     await fetchWork(
       experimentId,
@@ -66,6 +67,22 @@ describe('fetchWork', () => {
         genes: ['A', 'B', 'C', 'D'],
       },
       mockReduxState(experimentId),
+      { timeout: 10 },
+    );
+
+    expect(mockSeekFromAPI).not.toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), GENE_EXPRESSION_ETAG,
+    );
+  });
+
+  it('Caching is disabled by default if environment is dev', async () => {
+    await fetchWork(
+      experimentId,
+      {
+        name: 'GeneExpression',
+        genes: ['A', 'B', 'C', 'D'],
+      },
+      mockReduxState(experimentId, Environment.DEVELOPMENT),
       { timeout: 10 },
     );
 

--- a/src/__test__/utils/work/fetchWork.test.js
+++ b/src/__test__/utils/work/fetchWork.test.js
@@ -90,4 +90,22 @@ describe('fetchWork', () => {
       expect.anything(), expect.anything(), expect.anything(), GENE_EXPRESSION_ETAG,
     );
   });
+
+  it('Setting cache to false in development enables cache', async () => {
+    Storage.prototype.getItem = jest.fn((key) => (key === 'disableCache' ? 'false' : null));
+
+    await fetchWork(
+      experimentId,
+      {
+        name: 'GeneExpression',
+        genes: ['A', 'B', 'C', 'D'],
+      },
+      mockReduxState(experimentId, Environment.DEVELOPMENT),
+      { timeout: 10 },
+    );
+
+    expect(mockSeekFromAPI).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.anything(), GENE_EXPRESSION_ETAG,
+    );
+  });
 });


### PR DESCRIPTION
# Background
#### Link to issue 

N.A.

#### Link to staging deployment URL 

https://ui-agi-disable-cache.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

- Localstorage [only stores values as string](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#description), so I'm fixing the equality so that caching can be disabled.

It's easier to test this in local. The code will set the localStorage to true by default in development. To test this :

1. Open your browser, go to Data Management, check if disableCache is set (`localStorage.getItem('disableCache')). If it is, erase it (`localStorage.removeItem('disableCache'))
2. Open an experiment, go to Volcano plot (or any other part of the platform which sends work to the worker).
3. Add `console.log("*** Etag", Etag)` on line 131 of `fetchWork`.
4. Do the action which fetches work from worker (e.g. run comparison in volcano plot)
5. Check that `disableCache` is set in localStorage (`localStorage.disableCache`). This should be 'true',
6. Take note of the generate ETag.
7. Run another action which fetches work. This ETag should be different from that in step 6.
8. Run the previous action which fetches work on step 4. If caching is disabled, this ETag should be the same as the one in step 6.

You can do a similar variation to the check above to enable caching in development. To do that, run `localStorage.setItem('disableCache','false')`, and then take note of the ETags. They ETag for a similar action should be the same.

# Changes
### Code changes

- Disable caching in development

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Code updates
Have best practices and ongoing refactors being observed in this PR

- [X] Migrated any selector / reducer used to the new format
- [X] Validated that current unit tests work as expected and are enough

### Testing
- [X] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
