### PR TITLE
Correct volcano plot dependency

### DIFF
--- a/src/pages/experiments/[experimentId]/plots-and-tables/volcano/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/volcano/index.jsx
@@ -95,9 +95,9 @@ const VolcanoPlotPage = (props) => {
   useEffect(() => {
     if (config && !_.isEqual(currentConfig.current !== config)) {
       currentConfig.current = config;
-      setSpec(generateSpec(config, plotData, maxYAxis));
+      setSpec(generateSpec(config, plotData));
     }
-  }, [config]);
+  }, [config, plotData]);
 
   const plotStylingControlsConfig = [
     {


### PR DESCRIPTION
# Background
#### Link to issue 

There is an issue in production where volcano plot initially render without data. This was a bug that's introduced with the latest PR to the volcano plot. This happens because the plot is not re-rendered when the data has finished being fetched.

#### Link to staging deployment URL 

https://ui-agi-ui561.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

https://github.com/biomage-ltd/ui/pull/550

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

- Added the correct dependencies to the useEffect which calculates the plot data.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Code updates
Have best practices and ongoing refactors being observed in this PR

- [X] Migrated any selector / reducer used to the new format
- [X] Validated that current unit tests work as expected and are enough

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
