### PR TITLE
[BIOMAGE-1598] sort DE results by logFC

### DIFF
--- a/src/__test__/components/data-exploration/differential-expression-tool/DiffExprResults.test.jsx
+++ b/src/__test__/components/data-exploration/differential-expression-tool/DiffExprResults.test.jsx
@@ -196,6 +196,22 @@ describe('DiffExprResults', () => {
     expect(table.getElement().props.data.length).toEqual(5);
   });
 
+  it('is sorted by descending logFC by default', () => {
+    const component = mount(
+      <Provider store={withResultStore}>
+        <DiffExprResults experimentId={experimentId} onGoBack={jest.fn()} width={100} height={200} />
+      </Provider>,
+    );
+
+    const table = component.find('Table');
+    expect(table.getElement().props.columns[1].sortOrder).toEqual(null);
+    expect(table.getElement().props.columns[2].sortOrder).toEqual('descend');
+    expect(table.getElement().props.columns[3].sortOrder).toEqual(null);
+    expect(table.getElement().props.columns[4].sortOrder).toEqual(null);
+    expect(table.getElement().props.columns[5].sortOrder).toEqual(null);
+    expect(table.getElement().props.columns[6].sortOrder).toEqual(null);
+  });
+
   it('can sort the gene names in alphabetical order', async () => {
     const newPagination = {
       current: 1,

--- a/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
@@ -180,8 +180,8 @@ const DiffExprResults = (props) => {
         experimentId={experimentId}
         initialTableState={{
           sorter: {
-            field: 'abszscore',
-            columnKey: 'abszscore',
+            field: 'logFC',
+            columnKey: 'logFC',
             order: 'descend',
           },
         }}


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/jira/software/c/projects/BIOMAGE/boards/1?modal=detail&selectedIssue=BIOMAGE-1598

#### Link to staging deployment URL 

https://ui-sort-de-result.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Code updates
Have best practices and ongoing refactors being observed in this PR

- [ ] Migrated any selector / reducer used to the new format
- [ ] Validated that current unit tests work as expected and are enough

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
