### PR TITLE
[BIOMAGE-1615] Fix download rds button

### DIFF
--- a/src/__test__/components/data-management/DownloadData.test.jsx
+++ b/src/__test__/components/data-management/DownloadData.test.jsx
@@ -209,7 +209,7 @@ describe('Download data menu', () => {
   });
 
   it('Downolods data properly', async () => {
-    getFromApiExpectOK.mockImplementation(() => Promise.resolve({ signedUrl: 'signedUrl' }));
+    getFromApiExpectOK.mockImplementation(() => Promise.resolve('signedUrl'));
     getBackendStatus.mockImplementation(() => () => ({
       status: {
         pipeline: {

--- a/src/components/data-management/DownloadDataButton.jsx
+++ b/src/components/data-management/DownloadDataButton.jsx
@@ -70,7 +70,8 @@ const DownloadDataButton = () => {
       if (!experimentId) throw new Error('No experimentId specified');
       if (!downloadTypes.has(type)) throw new Error('Invalid download type');
 
-      const { signedUrl } = await getFromApiExpectOK(`/v1/experiments/${experimentId}/download/${type}`);
+      const signedUrl = await getFromApiExpectOK(`/v1/experiments/${experimentId}/download/${type}`);
+
       downloadFromUrl(signedUrl);
     } catch (e) {
       pushNotificationMessage('error', endUserMessages.ERROR_DOWNLOADING_DATA);


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1615

#### Link to staging deployment URL 
https://ui-martinfosco-ui581-api269.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/api/pull/269/files

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Code updates
Have best practices and ongoing refactors being observed in this PR

- [ ] Migrated any selector / reducer used to the new format
- [ ] Validated that current unit tests work as expected and are enough

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
