### PR TITLE
Make user pool name more specific

### DIFF
--- a/src/utils/ssr/getAuthenticationInfo.js
+++ b/src/utils/ssr/getAuthenticationInfo.js
@@ -57,12 +57,13 @@ const getAuthenticationInfo = async () => {
    * local development.
    */
   const k8sEnv = process.env.K8S_ENV || 'staging';
+  const userPoolName = `user-pool-${k8sEnv}`;
 
   const identityPoolId = IdentityPools.find(
     (pool) => pool.IdentityPoolName.includes(`${k8sEnv}-${sandboxId}`),
   ).IdentityPoolId;
 
-  const userPoolId = UserPools.find((pool) => pool.Name.includes(k8sEnv)).Id;
+  const userPoolId = UserPools.find((pool) => pool.Name.includes(userPoolName)).Id;
 
   const { UserPoolClients } = await userPoolClient.send(
     new ListUserPoolClientsCommand({ UserPoolId: userPoolId, MaxResults: 60 }),

--- a/src/utils/ssr/getAuthenticationInfo.js
+++ b/src/utils/ssr/getAuthenticationInfo.js
@@ -57,13 +57,13 @@ const getAuthenticationInfo = async () => {
    * local development.
    */
   const k8sEnv = process.env.K8S_ENV || 'staging';
-  const userPoolName = `user-pool-${k8sEnv}`;
+  const userPoolName = `biomage-user-pool-${k8sEnv}`;
 
   const identityPoolId = IdentityPools.find(
     (pool) => pool.IdentityPoolName.includes(`${k8sEnv}-${sandboxId}`),
   ).IdentityPoolId;
 
-  const userPoolId = UserPools.find((pool) => pool.Name.includes(userPoolName)).Id;
+  const userPoolId = UserPools.find((pool) => pool.Name === userPoolName).Id;
 
   const { UserPoolClients } = await userPoolClient.send(
     new ListUserPoolClientsCommand({ UserPoolId: userPoolId, MaxResults: 60 }),


### PR DESCRIPTION
# Background
#### Link to issue 

https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1639748257004800

#### Link to staging deployment URL

https://ui-agi-ui590.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

N/A

#### Anything else the reviewers should know about the changes here

-  Making the regex to match the user pool name more specific so we can add additional pool names without causing errors.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Code updates
Have best practices and ongoing refactors being observed in this PR

- [ ] Migrated any selector / reducer used to the new format
- [ ] Validated that current unit tests work as expected and are enough

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
