### PR TITLE
[BIOMAGE-1722] - Add zscore calculation after loading gene expression

### DIFF
--- a/src/__test__/redux/reducers/genes/__snapshots__/genesExpressionLoaded.test.js.snap
+++ b/src/__test__/redux/reducers/genes/__snapshots__/genesExpressionLoaded.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`genesExpressionLoaded reducer returns correct state 1`] = `
+Object {
+  "expression": Object {
+    "data": Object {
+      "geneA": Object {
+        "rawExpression": Object {
+          "expression": Array [
+            1,
+          ],
+          "mean": 1,
+          "stdev": 1,
+        },
+        "zScore": Array [
+          0,
+        ],
+      },
+    },
+    "loading": Array [],
+    "views": Object {
+      "undefined": Object {
+        "data": Array [
+          "geneA",
+        ],
+        "error": false,
+        "fetching": false,
+      },
+    },
+  },
+  "markers": Object {},
+}
+`;

--- a/src/__test__/redux/reducers/genes/genesExpressionLoaded.test.js
+++ b/src/__test__/redux/reducers/genes/genesExpressionLoaded.test.js
@@ -1,0 +1,34 @@
+import genesExpressionLoadedReducer from 'redux/reducers/genes/genesExpressionLoaded';
+
+describe('genesExpressionLoaded reducer', () => {
+  it('returns correct state', () => {
+    const initialState = {
+      expression: {
+        views: {},
+        data: {},
+      },
+      markers: {},
+    };
+
+    const genes = ['geneA'];
+    const data = {
+      geneA: {
+        rawExpression: {
+          expression: [1],
+          mean: 1,
+          stdev: 1,
+        },
+      },
+    };
+
+    const newState = genesExpressionLoadedReducer(initialState, {
+      payload: {
+        genes,
+        data,
+        plotUuid: 'interactiveHeatmap',
+      },
+    });
+
+    expect(newState).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
# Description
Add zscore calculation when loading gene expressoin.

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1722

#### Link to staging deployment URL (or set N/A)
Coming soon

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [X] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [X] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [X] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [X] Unit tests written **or** no unit tests required for change, e.g. documentation update.


### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [X] Relevant Github READMEs updated **or** no GitHub README updates required.
- [X] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.