### PR TITLE
[BIOMAGE-1685] - Add DE information baloons

### DIFF
--- a/src/__test__/components/data-exploration/differential-expression-tool/DiffExprCompute.test.jsx
+++ b/src/__test__/components/data-exploration/differential-expression-tool/DiffExprCompute.test.jsx
@@ -132,11 +132,13 @@ describe('DiffExprCompute', () => {
 
     // Get the input radio button element for the selection
     const withinRadioButton = screen.getByText(/Compare cell sets within a sample\/group/i)
-      .previousSibling.firstChild;
+      .closest('label').querySelector("input[type='radio']");
+
     expect(withinRadioButton).toBeEnabled();
 
     const betweenRadioButton = screen.getByText(/Compare a selected cell set between samples\/groups/i)
-      .previousSibling.firstChild;
+      .closest('label').querySelector("input[type='radio']");
+
     expect(betweenRadioButton).toBeDisabled();
   });
 

--- a/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
@@ -270,11 +270,6 @@ const DiffExprCompute = (props) => {
     );
   };
 
-  const radioStyle = {
-    display: 'block',
-    height: '30px',
-    lineHeight: '30px',
-  };
 
   return (
     <Form size='small' layout='vertical'>
@@ -283,7 +278,6 @@ const DiffExprCompute = (props) => {
         dispatch(setComparisonType(e.target.value));
       }} defaultValue={selectedComparison}>
         <Radio
-          style={radioStyle}
           value={ComparisonType.WITHIN}>
           <Space>
             Compare cell sets within a sample/group
@@ -306,7 +300,6 @@ const DiffExprCompute = (props) => {
           </Space>
         </Radio>
         <Radio
-          style={radioStyle}
           value={ComparisonType.BETWEEN}
           disabled={numSamples === 1}
         >

--- a/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
@@ -283,7 +283,7 @@ const DiffExprCompute = (props) => {
             Compare cell sets within a sample/group
             <Tooltip overlay={(
               <span>
-                This is useful for finding differentially expressed genes when comparing cell sets (e.g. for finding marker genes that distinguish one cluster from another). The calculation uses the presto implementation of the Wilcoxon rank sum test and auROC analysis. For more information see the
+                This is useful for finding marker genes that distinguish one cluster from another. The calculation uses the presto implementation of the Wilcoxon rank sum test and auROC analysis. For more information see the
                 {' '}
                 <a
                   href='http://htmlpreview.github.io/?https://github.com/immunogenomics/presto/blob/master/docs/getting-started.html'
@@ -317,14 +317,14 @@ const DiffExprCompute = (props) => {
             }
             <Tooltip overlay={(
               <span>
-                This is useful for finding differentially expressed genes when comparing two experimental groups or two samples. This analysis uses the voom workflow from the limma R package. For more information see the
+                This is useful for finding differentially expressed genes when comparing two experimental groups. This analysis uses a
                 {' '}
                 <a
-                  href='https://www.bioconductor.org/packages/devel/bioc/vignettes/limma/inst/doc/usersguide.pdf'
+                  href='http://bioconductor.org/books/3.14/OSCA.workflows/segerstolpe-human-pancreas-smart-seq2.html#segerstolpe-comparison'
                   target='_blank'
                   rel='noreferrer'
                 >
-                  limma vignette
+                  limma-voom workflow
                 </a>.
               </span>
             )}

--- a/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
@@ -285,14 +285,60 @@ const DiffExprCompute = (props) => {
         <Radio
           style={radioStyle}
           value={ComparisonType.WITHIN}>
-          Compare cell sets within a sample/group
+          <Space>
+            Compare cell sets within a sample/group
+            <Tooltip overlay={(
+              <span>
+                This is useful for finding differentially expressed genes when comparing cell sets (e.g. for finding marker genes that distinguish one cluster from another). The calculation uses the presto implementation of the Wilcoxon rank sum test and auROC analysis. For more information see the
+                {' '}
+                <a
+                  href='http://htmlpreview.github.io/?https://github.com/immunogenomics/presto/blob/master/docs/getting-started.html'
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  presto vignette
+                </a>.
+              </span>
+            )}
+            >
+              <InfoCircleOutlined />
+            </Tooltip>
+          </Space>
         </Radio>
         <Radio
           style={radioStyle}
           value={ComparisonType.BETWEEN}
           disabled={numSamples === 1}
         >
-          Compare a selected cell set between samples/groups
+          <Space>
+            {
+              numSamples === 1 ? (
+                <Tooltip
+                  overlay={(<span>Comparison between samples/groups is not possible with a dataset that contains only 1 sample</span>)}
+                >
+                  Compare a selected cell set between samples/groups
+                </Tooltip>
+              ) : (
+                'Compare a selected cell set between samples/groups'
+              )
+            }
+            <Tooltip overlay={(
+              <span>
+                This is useful for finding differentially expressed genes when comparing two experimental groups or two samples. This analysis uses the voom workflow from the limma R package. For more information see the
+                {' '}
+                <a
+                  href='https://www.bioconductor.org/packages/devel/bioc/vignettes/limma/inst/doc/usersguide.pdf'
+                  target='_blank'
+                  rel='noreferrer'
+                >
+                  limma vignette
+                </a>.
+              </span>
+            )}
+            >
+              <InfoCircleOutlined />
+            </Tooltip>
+          </Space>
         </Radio>
       </Radio.Group>
 
@@ -361,22 +407,6 @@ const DiffExprCompute = (props) => {
           >
             Compute
           </Button>
-          <Tooltip overlay={(
-            <span>
-              Differential expression is calculated using the presto implementation of the Wilcoxon rank sum test and auROC analysis. For more information see the
-              {' '}
-              <a
-                href='http://htmlpreview.github.io/?https://github.com/immunogenomics/presto/blob/master/docs/getting-started.html'
-                target='_blank'
-                rel='noreferrer'
-              >
-                presto vignette
-              </a>.
-            </span>
-          )}
-          >
-            <InfoCircleOutlined />
-          </Tooltip>
         </Space>
       </Space>
     </Form>


### PR DESCRIPTION
# Description
- Add information baloons for differential expression.
- Add information tooltip on the 2nd ("between group") DE option when disabled.


# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1685

#### Link to staging deployment URL (or set N/A)
https://ui-agi-ui649.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
N/A

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [X] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [X] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [X] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [X] Unit tests written **or** no unit tests required for change, e.g. documentation update.


### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [X] Relevant Github READMEs updated **or** no GitHub README updates required.
- [X] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.