### PR TITLE
[BIOMAGE-1765] - Use correct environment in error boundary

### DIFF
--- a/src/__test__/components/ErrorBoundary.test.jsx
+++ b/src/__test__/components/ErrorBoundary.test.jsx
@@ -6,6 +6,7 @@ import { makeStore } from 'redux/store';
 import postErrorToSlack from 'utils/postErrorToSlack';
 
 import ErrorBoundary from 'components/ErrorBoundary';
+import loadEnvironment from 'redux/actions/networkResources/loadEnvironment';
 
 const content = 'Some content';
 
@@ -38,9 +39,8 @@ let storeState = null;
 describe('ErrorBoundary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    process.env.NODE_ENV = 'production';
     storeState = makeStore();
+    storeState.dispatch(loadEnvironment('production'));
   });
 
   it('Does not render if there is no error', () => {
@@ -66,8 +66,7 @@ describe('ErrorBoundary', () => {
   });
 
   it('Should not post error if environment is not production', async () => {
-    process.env.NODE_ENV = 'staging';
-
+    storeState.dispatch(loadEnvironment('staging'));
     renderErrorBoundary(storeState);
 
     expect(postErrorToSlack).not.toHaveBeenCalled();

--- a/src/__test__/components/__snapshots__/ErrorBoundary.test.jsx.snap
+++ b/src/__test__/components/__snapshots__/ErrorBoundary.test.jsx.snap
@@ -5,10 +5,10 @@ Array [
   [Error: test],
   Object {
     "componentStack": "
-    in ThrowError (at ErrorBoundary.test.jsx:30)
+    in ThrowError (at ErrorBoundary.test.jsx:31)
     in ErrorBoundary (created by Connect(ErrorBoundary))
-    in Connect(ErrorBoundary) (at ErrorBoundary.test.jsx:29)
-    in Provider (at ErrorBoundary.test.jsx:28)",
+    in Connect(ErrorBoundary) (at ErrorBoundary.test.jsx:30)
+    in Provider (at ErrorBoundary.test.jsx:29)",
   },
   Object {
     "backendStatus": Object {},
@@ -138,7 +138,7 @@ Array [
       },
     },
     "networkResources": Object {
-      "environment": undefined,
+      "environment": "production",
     },
     "projects": Object {
       "ids": Array [],

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -6,6 +6,8 @@ import { connect } from 'react-redux';
 import Error from 'pages/_error';
 
 // Implementation of https://reactjs.org/docs/error-boundaries.html
+// Using React class because it's not yet supported for functional components
+// according to https://stackoverflow.com/a/68075800/1940886
 class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import PropTypes from 'prop-types';
 import postErrorToSlack from 'utils/postErrorToSlack';
@@ -18,29 +19,28 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, errorInfo) {
     // Act on the error inside this function
-    if (process.env.NODE_ENV !== 'production') return;
+    if (this.props.environment !== 'production') return;
     const { reduxDump } = this.props;
     postErrorToSlack(error, errorInfo, reduxDump);
   }
 
   render() {
-    const { hasError } = this.state;
-    const { children } = this.props;
+    if (this.state.hasError) return <Error />;
 
-    if (hasError) return <Error />;
-
-    return children;
+    return this.props.children;
   }
 }
 
 function mapStateToProps(state) {
   return {
+    environment: state.networkResources.environment,
     reduxDump: state,
   };
 }
 
 ErrorBoundary.propTypes = {
   reduxDump: PropTypes.object,
+  environment: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
 };
 


### PR DESCRIPTION
# Description
Error boundary is sending error logs even when not in production. This is due to the incorrect way used to get the environment. `process.env` is not defined in the browser, so we should be using `state.networkResrouces.environment` instead.

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1765

#### Link to staging deployment URL (or set N/A)
https://ui-agi-ui658.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/ui/pull/654

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [X] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [X] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [X] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [X] Unit tests written **or** no unit tests required for change, e.g. documentation update.


### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [X] Relevant Github READMEs updated **or** no GitHub README updates required.
- [X] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.