### PR TITLE
[BIOMAGE-1807] - Fix error fetching pipeline status on re-run

### DIFF
--- a/src/components/data-processing/StatusIndicator.jsx
+++ b/src/components/data-processing/StatusIndicator.jsx
@@ -29,14 +29,14 @@ const StatusIndicator = (props) => {
   } = props;
 
   const {
-    status: { pipeline },
+    status: backendStatus,
     loading: loadingBackendStatus,
     error: errorLoadingBackendStatus,
   } = useSelector(getBackendStatus(experimentId));
 
   const {
     startDate, stopDate, status, error,
-  } = pipeline;
+  } = backendStatus?.pipeline || {};
 
   const statusIndicators = {
     [pipelineStatus.NOT_CREATED]: {


### PR DESCRIPTION
# Description
There is an error thrown in the Data Processing in the UI when we re-run pipeine status. This error happens because the default value of backend status is set to `null` when re-running the QC. However we're trying get the property `pipeline` from it, so it throws an error.

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1807

#### Link to staging deployment URL (or set N/A)
https://ui-agi-pass-please.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
#660 

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [X] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [X] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [X] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [X] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [X] Relevant Github READMEs updated **or** no GitHub README updates required.
- [X] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [X] Staging environment is unstaged before merging.
- [X] Photo of a cute animal attached to this PR.