### PR TITLE
[BIOMAGE-1851] - Copy plotData objects in plot

### DIFF
--- a/src/components/plots/CellSizeDistributionHistogram.jsx
+++ b/src/components/plots/CellSizeDistributionHistogram.jsx
@@ -14,6 +14,7 @@ const CellSizeDistributionHistogram = (props) => {
 
   useEffect(() => {
     if (config && plotData) {
+      console.log('*** config', config);
       setPlotSpec(generateSpec(config, plotData, highestUmi));
     }
   }, [config, plotData]);

--- a/src/components/plots/CellSizeDistributionHistogram.jsx
+++ b/src/components/plots/CellSizeDistributionHistogram.jsx
@@ -14,7 +14,6 @@ const CellSizeDistributionHistogram = (props) => {
 
   useEffect(() => {
     if (config && plotData) {
-      console.log('*** config', config);
       setPlotSpec(generateSpec(config, plotData, highestUmi));
     }
   }, [config, plotData]);

--- a/src/components/plots/DotPlot.jsx
+++ b/src/components/plots/DotPlot.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Vega } from 'react-vega';
@@ -15,13 +15,6 @@ const DotPlot = (props) => {
   const { loading: cellSetsLoading, error: cellSetsError } = useSelector(getCellSets());
   const cellSet = useSelector(getCellSetsHierarchyByKeys([config.selectedCellSet]))[0];
   const numClusters = cellSet ? cellSet.children.length : 0;
-  const data = useRef(plotData);
-
-  useEffect(() => {
-    if (data.current !== plotData) {
-      data.current = plotData;
-    }
-  }, [plotData]);
 
   const actions = {
     export: true,
@@ -50,7 +43,7 @@ const DotPlot = (props) => {
     }
 
     // PlotData has to be cloned for this plot because Immer freezes plotData meanwhile the plot needs to modify it to work
-    return <Vega spec={generateSpec(config, data.current, numClusters)} renderer='canvas' actions={actions} />;
+    return <Vega spec={generateSpec(config, plotData, numClusters)} renderer='canvas' actions={actions} />;
   };
 
   return render();

--- a/src/utils/plotSpecs/generateCellSizeDistributionHistogram.js
+++ b/src/utils/plotSpecs/generateCellSizeDistributionHistogram.js
@@ -49,6 +49,13 @@ const generateSpec = (config, plotData, highestUmi) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
       {
         name: 'binned',

--- a/src/utils/plotSpecs/generateCellSizeDistributionKneePlot.js
+++ b/src/utils/plotSpecs/generateCellSizeDistributionKneePlot.js
@@ -57,6 +57,13 @@ const generateSpec = (config, plotData) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
         transform: [
           {
             type: 'formula',

--- a/src/utils/plotSpecs/generateClassifierEmptyDropsPlot.js
+++ b/src/utils/plotSpecs/generateClassifierEmptyDropsPlot.js
@@ -9,6 +9,13 @@ const generateSpec = (config, expConfig, plotData) => ({
     {
       name: 'plotData',
       values: plotData,
+      // Vega internally modifies objects during data transforms. If the plot data is frozen,
+      // Vega is not able to carry out the transform and will throw an error.
+      // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+      format: {
+        type: 'json',
+        copy: true,
+      },
       transform: [
         {
           type: 'filter',

--- a/src/utils/plotSpecs/generateClassifierKneePlot.js
+++ b/src/utils/plotSpecs/generateClassifierKneePlot.js
@@ -101,6 +101,13 @@ const generateSpec = (config, { FDR }, plotData) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
       {
         name: 'lowerHalfPlotData',

--- a/src/utils/plotSpecs/generateDotPlotSpec.js
+++ b/src/utils/plotSpecs/generateDotPlotSpec.js
@@ -85,6 +85,13 @@ const generateSpec = (config, plotData, numClusters) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
         transform: [
           {
             type: 'formula',

--- a/src/utils/plotSpecs/generateDoubletScoreHistogram.js
+++ b/src/utils/plotSpecs/generateDoubletScoreHistogram.js
@@ -45,6 +45,13 @@ const generateSpec = (config, plotData) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
       {
         name: 'binned',

--- a/src/utils/plotSpecs/generateElbowSpec.js
+++ b/src/utils/plotSpecs/generateElbowSpec.js
@@ -11,6 +11,13 @@ const generateSpec = (config, plotData, numPCs) => ({
     {
       name: 'plotData',
       values: plotData,
+      // Vega internally modifies objects during data transforms. If the plot data is frozen,
+      // Vega is not able to carry out the transform and will throw an error.
+      // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+      format: {
+        type: 'json',
+        copy: true,
+      },
       transform: [
         {
           type: 'formula',

--- a/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
+++ b/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
@@ -51,6 +51,13 @@ const generateSpec = (config, plotData, cellSetLegendsData) => {
       {
         name: 'values',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
       {
         name: 'labels',

--- a/src/utils/plotSpecs/generateFeaturesVsUMIsScatterplot.js
+++ b/src/utils/plotSpecs/generateFeaturesVsUMIsScatterplot.js
@@ -18,6 +18,13 @@ const generateSpec = (config, plotData) => {
       {
         name: 'pointsData',
         values: pointsData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
         transform: [
           {
             type: 'filter',
@@ -32,6 +39,13 @@ const generateSpec = (config, plotData) => {
       {
         name: 'linesData',
         values: linesData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
     ],
 

--- a/src/utils/plotSpecs/generateFrequencySpec.js
+++ b/src/utils/plotSpecs/generateFrequencySpec.js
@@ -53,6 +53,13 @@ const generateSpec = (config, plotData, xNamesToDisplay, yNamesToDisplay) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
         transform: [
           {
             type: 'stack',

--- a/src/utils/plotSpecs/generateMitochondrialFractionHistogram.js
+++ b/src/utils/plotSpecs/generateMitochondrialFractionHistogram.js
@@ -49,6 +49,13 @@ const generateSpec = (config, plotData) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
       {
         name: 'binned',

--- a/src/utils/plotSpecs/generateMitochondrialFractionScatterplot.js
+++ b/src/utils/plotSpecs/generateMitochondrialFractionScatterplot.js
@@ -47,6 +47,13 @@ const generateSpec = (config, plotData) => {
       {
         name: 'plotData',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
         transform: [
           {
             type: 'formula',

--- a/src/utils/plotSpecs/generateViolinSpec.js
+++ b/src/utils/plotSpecs/generateViolinSpec.js
@@ -29,10 +29,24 @@ const generateSpec = (config, plotData) => {
       {
         name: 'groupCfg',
         values: plotData.groups,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
       {
         name: 'cells',
         values: plotData.cells,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
       },
       {
         name: 'density',

--- a/src/utils/plotSpecs/generateVolcanoSpec.js
+++ b/src/utils/plotSpecs/generateVolcanoSpec.js
@@ -79,6 +79,13 @@ const generateSpec = (configSrc, plotData) => {
       {
         name: 'data',
         values: plotData,
+        // Vega internally modifies objects during data transforms. If the plot data is frozen,
+        // Vega is not able to carry out the transform and will throw an error.
+        // https://github.com/vega/vega/issues/2453#issuecomment-604516777
+        format: {
+          type: 'json',
+          copy: true,
+        },
         transform: [
           {
             type: 'filter',


### PR DESCRIPTION
# Description
Using immer freezes objects in plotData. This causes issues with Vega, whose transform functions modify plotData.

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1851

Staging:
https://ui-agi-scanty-swan.scp-staging.biomage.net/
#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.