### PR TITLE
Fix project details scrolling issue

### DIFF
--- a/src/components/data-management/ProjectDetails.jsx
+++ b/src/components/data-management/ProjectDetails.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
 import {
   Space, Typography, Button,
 } from 'antd';
@@ -9,6 +10,7 @@ import {
 import { updateProject } from 'redux/actions/projects';
 import { updateExperiment } from 'redux/actions/experiments';
 
+import { layout } from 'utils/constants';
 import EditableParagraph from 'components/EditableParagraph';
 import SamplesTable from './SamplesTable';
 import ProjectMenu from './ProjectMenu';
@@ -17,7 +19,12 @@ const {
   Title, Text,
 } = Typography;
 
-const ProjectDetails = () => {
+const paddingTop = layout.PANEL_PADDING;
+const paddingBottom = layout.PANEL_PADDING;
+const paddingRight = layout.PANEL_PADDING;
+const paddingLeft = layout.PANEL_PADDING;
+
+const ProjectDetails = ({ width, height }) => {
   const dispatch = useDispatch();
 
   const { activeProjectUuid } = useSelector((state) => state.projects.meta);
@@ -25,48 +32,60 @@ const ProjectDetails = () => {
   const samplesTableRef = useRef();
 
   return (
+    // The height of this div has to be fixed to enable sample scrolling
     <div
       id='project-details'
       style={{
-        display: 'flex', flexDirection: 'column', height: '100%', width: '100%',
+        width: width - paddingLeft - paddingRight,
+        height: height - layout.PANEL_HEADING_HEIGHT - paddingTop - paddingBottom,
       }}
     >
-      <div style={{ flex: 'none', paddingBottom: '1em' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <Title level={3}>{activeProject.name}</Title>
-          <Space>
-            <Button
-              disabled={activeProject.samples?.length === 0}
-              onClick={() => samplesTableRef.current.createMetadataColumn()}
-            >
-              Add metadata
-            </Button>
-            <ProjectMenu />
-          </Space>
+      <div style={{
+        display: 'flex', flexDirection: 'column', height: '100%', width: '100%',
+      }}
+      >
+        <div style={{ flex: 'none', paddingBottom: '1em' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Title level={3}>{activeProject.name}</Title>
+            <Space>
+              <Button
+                disabled={activeProject.samples?.length === 0}
+                onClick={() => samplesTableRef.current.createMetadataColumn()}
+              >
+                Add metadata
+              </Button>
+              <ProjectMenu />
+            </Space>
+          </div>
+          <Text type='secondary'>
+            {`Project ID: ${activeProjectUuid}`}
+          </Text>
         </div>
-        <Text type='secondary'>
-          {`Project ID: ${activeProjectUuid}`}
-        </Text>
-      </div>
-      <div style={{ flex: 1, overflowY: 'auto' }}>
-        <Text strong>
-          Description:
-        </Text>
-        <EditableParagraph
-          value={activeProject.description}
-          onUpdate={(text) => {
-            if (text !== activeProject.description) {
-              dispatch(updateProject(activeProjectUuid, { description: text }));
-              dispatch(updateExperiment(activeProject.experiments[0], { description: text }));
-            }
-          }}
-        />
-        <SamplesTable
-          ref={samplesTableRef}
-        />
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          <Text strong>
+            Description:
+          </Text>
+          <EditableParagraph
+            value={activeProject.description}
+            onUpdate={(text) => {
+              if (text !== activeProject.description) {
+                dispatch(updateProject(activeProjectUuid, { description: text }));
+                dispatch(updateExperiment(activeProject.experiments[0], { description: text }));
+              }
+            }}
+          />
+          <SamplesTable
+            ref={samplesTableRef}
+          />
+        </div>
       </div>
     </div>
   );
+};
+
+ProjectDetails.propTypes = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
 };
 
 export default ProjectDetails;

--- a/src/pages/data-management/index.jsx
+++ b/src/pages/data-management/index.jsx
@@ -93,7 +93,7 @@ const DataManagementPage = () => {
     },
     [PROJECT_DETAILS]: {
       toolbarControls: [],
-      component: () => {
+      component: (width, height) => {
         if (!activeProjectUuid) {
           return (
             <Empty
@@ -104,7 +104,12 @@ const DataManagementPage = () => {
           );
         }
 
-        return (<ProjectDetails />);
+        return (
+          <ProjectDetails
+            width={width}
+            height={height}
+          />
+        );
       },
     },
   };


### PR DESCRIPTION
# Description
#### Background
Changes to `ProjectDetails` in PR#690 causes the samples table to lose scrolling when samples table is long.

#### Solution
Reintroduce a container div with fixed width and height

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
https://ui-agi-slaphappy-axolotl.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/ui/pull/690

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.