### PR TITLE
Hotfix experiments loaded reducer

### DIFF
--- a/src/__test__/redux/reducers/__snapshots__/experimentsReducer.test.js.snap
+++ b/src/__test__/redux/reducers/__snapshots__/experimentsReducer.test.js.snap
@@ -268,6 +268,18 @@ Object {
 }
 `;
 
+exports[`experimentsReducer Loads 0 experiments correctly 1`] = `
+Object {
+  "ids": Array [],
+  "meta": Object {
+    "activeExperimentId": undefined,
+    "error": false,
+    "loading": false,
+    "saving": false,
+  },
+}
+`;
+
 exports[`experimentsReducer Loads an experiment correctly 1`] = `
 Object {
   "experiment-1": Object {

--- a/src/__test__/redux/reducers/experimentsReducer.test.js
+++ b/src/__test__/redux/reducers/experimentsReducer.test.js
@@ -145,6 +145,18 @@ describe('experimentsReducer', () => {
     expect(newState).toMatchSnapshot();
   });
 
+  it('Loads 0 experiments correctly', () => {
+    const newState = experimentsReducer(initialState, {
+      type: EXPERIMENTS_LOADED,
+      payload: {
+        experiments: [],
+      },
+    });
+    expect(newState.ids).toEqual([]);
+    expect(newState.meta.activeExperimentId).toEqual(undefined);
+    expect(newState).toMatchSnapshot();
+  });
+
   it('Loading state changes meta state', () => {
     const newState = experimentsReducer(initialState, {
       type: EXPERIMENTS_LOADING,

--- a/src/redux/reducers/experiments/experimentsLoaded.js
+++ b/src/redux/reducers/experiments/experimentsLoaded.js
@@ -17,7 +17,7 @@ const experimentsLoaded = produce((draft, action) => {
 
   const ids = _.map(experiments, 'id');
 
-  draft.meta.activeExperimentId = experiments[0].id;
+  draft.meta.activeExperimentId = experiments[0]?.id;
   draft.meta.loading = false;
   draft.ids = ids;
 


### PR DESCRIPTION
# Description
`experimentsLoaded`, a reducer in the `experiments` slice, fails when the user that it is storing experiments for has no experiments. This bug was introducer in my PR of refactoring that removes projects from redux

# Details
#### URL to issue
N/A
<!---
  Delete this comment and include the URL of the issue the pull request is related to.
  If no issue exists for this PR, replace this comment with N/A.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Link to staging deployment URL (or set N/A)
<!---
  Delete this comment and include the URL of the staging environment for this pull request.
  Refer to https://github.com/hms-dbmi-cellenics/biomage-utils#stage on how to stage a staging environment.
  If a staging environment for testing is not necessary for this PR, replace this comment with N/A 
  and explain why a staging environment is not required for this PR.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `biomage experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.