### PR TITLE
Make sure that labels is not in plot config when they are disabled

### DIFF
--- a/src/components/plots/styling/PlotStyling.jsx
+++ b/src/components/plots/styling/PlotStyling.jsx
@@ -45,7 +45,7 @@ const PlotStyling = (props) => {
     expressionValuesCapping: (attr) => <ExpressionValuesCapping key='expressionValuesCapping' config={config} onUpdate={onUpdate} {...attr} />,
     markers: (attr) => <PointDesign key='markers' config={config} onUpdate={onUpdate} {...attr} />,
     legend: (attr) => <LegendEditor key='legend' onUpdate={onUpdate} config={config} {...attr} />,
-    labels: (attr) => <LabelsDesign key='legend' onUpdate={onUpdate} config={config} {...attr} />,
+    labels: (attr) => <LabelsDesign key='labels' onUpdate={onUpdate} config={config} {...attr} />,
     violinMarkers: (attr) => <ViolinMarkersEditor key='violinMarkers' config={config} onUpdate={onUpdate} {...attr} />,
     volcanoThresholds: (attr) => <VolcanoThresholdsGuidesEditor key='volcanoThresholds' config={config} onUpdate={onUpdate} {...attr} />,
     volcanoMarkers: (attr) => <VolcanoMarkersEditor key='volcanoMarkers' config={config} onUpdate={onUpdate} {...attr} />,

--- a/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
+++ b/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
@@ -14,6 +14,52 @@ const generateSpec = (config, plotData, cellSetLegendsData) => {
     : [config.axesRanges.yMin, config.axesRanges.yMax];
 
   let legend = [];
+  let marks = [
+    {
+      type: 'symbol',
+      clip: true,
+      from: { data: 'values' },
+      encode: {
+        enter: {
+          x: { scale: 'x', field: 'x' },
+          y: { scale: 'y', field: 'y' },
+          size: [
+            {
+              test: "inrange(datum.x, domain('x')) && inrange(datum.y, domain('y'))",
+              value: config?.marker.size,
+            },
+            { value: 0 },
+          ],
+          stroke: { scale: 'cellSetMarkColors', field: 'cellSetKey' },
+          fill: { scale: 'cellSetMarkColors', field: 'cellSetKey' },
+          shape: { value: 'circle' },
+          fillOpacity: { value: config?.marker.opacity / 10 },
+        },
+      },
+    }
+  ];
+
+  if (config?.labels.enabled) {
+    marks.push(
+      {
+        type: 'text',
+        clip: true,
+        from: { data: 'labels' },
+        encode: {
+          enter: {
+            x: { scale: 'x', field: 'meanX' },
+            y: { scale: 'y', field: 'meanY' },
+            text: { field: 'cellSetName' },
+            fontSize: { value: config?.labels.size },
+            strokeWidth: { value: 1.2 },
+            fill: { value: config?.colour.masterColour },
+            fillOpacity: { value: config?.labels.enabled },
+            font: { value: config?.fontStyle.font },
+          },
+        },
+      }
+    )
+  }
 
   // removing empty/unused entries from the data. This was causing issues with the legend
   // example of an entry {
@@ -195,47 +241,7 @@ const generateSpec = (config, plotData, cellSetLegendsData) => {
         domainWidth: config?.axes.domainWidth,
       },
     ],
-    marks: [
-      {
-        type: 'symbol',
-        clip: true,
-        from: { data: 'values' },
-        encode: {
-          enter: {
-            x: { scale: 'x', field: 'x' },
-            y: { scale: 'y', field: 'y' },
-            size: [
-              {
-                test: "inrange(datum.x, domain('x')) && inrange(datum.y, domain('y'))",
-                value: config?.marker.size,
-              },
-              { value: 0 },
-            ],
-            stroke: { scale: 'cellSetMarkColors', field: 'cellSetKey' },
-            fill: { scale: 'cellSetMarkColors', field: 'cellSetKey' },
-            shape: { value: 'circle' },
-            fillOpacity: { value: config?.marker.opacity / 10 },
-          },
-        },
-      },
-      {
-        type: 'text',
-        clip: true,
-        from: { data: 'labels' },
-        encode: {
-          enter: {
-            x: { scale: 'x', field: 'meanX' },
-            y: { scale: 'y', field: 'meanY' },
-            text: { field: 'cellSetName' },
-            fontSize: { value: config?.labels.size },
-            strokeWidth: { value: 1.2 },
-            fill: { value: config?.colour.masterColour },
-            fillOpacity: { value: config?.labels.enabled },
-            font: { value: config?.fontStyle.font },
-          },
-        },
-      },
-    ],
+    marks: marks,
     legends: legend,
     title:
     {

--- a/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
+++ b/src/utils/plotSpecs/generateEmbeddingCategoricalSpec.js
@@ -14,7 +14,7 @@ const generateSpec = (config, plotData, cellSetLegendsData) => {
     : [config.axesRanges.yMin, config.axesRanges.yMax];
 
   let legend = [];
-  let marks = [
+  const marks = [
     {
       type: 'symbol',
       clip: true,
@@ -36,7 +36,7 @@ const generateSpec = (config, plotData, cellSetLegendsData) => {
           fillOpacity: { value: config?.marker.opacity / 10 },
         },
       },
-    }
+    },
   ];
 
   if (config?.labels.enabled) {
@@ -57,8 +57,8 @@ const generateSpec = (config, plotData, cellSetLegendsData) => {
             font: { value: config?.fontStyle.font },
           },
         },
-      }
-    )
+      },
+    );
   }
 
   // removing empty/unused entries from the data. This was causing issues with the legend
@@ -241,7 +241,7 @@ const generateSpec = (config, plotData, cellSetLegendsData) => {
         domainWidth: config?.axes.domainWidth,
       },
     ],
-    marks: marks,
+    marks,
     legends: legend,
     title:
     {


### PR DESCRIPTION
# Description
See https://github.com/hms-dbmi-cellenics/issues/issues/47

Staging: https://ui-ivababukova-ui9.scp-staging.biomage.net/


# Details
#### URL to issue
In the Vega config, the labels are defined under `marks`. This bug was happening, because `marks` always had a constant value, regardless of whether labels are enabled or not. What I don't understand is why would the labels show and hide correctly on the actual plot, and on the download fro PNG button.

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
