### PR TITLE
fix(seekFromS3): returning null on 404 error as expected

### DIFF
--- a/src/__test__/utils/work/seekWorkResponse.test.js
+++ b/src/__test__/utils/work/seekWorkResponse.test.js
@@ -157,8 +157,10 @@ describe('seekFromS3 unit tests', () => {
 
   const validSignedUrl = 'https://s3.mock/validSignedUrl';
   const invalidSignedUrl = 'https://s3.mock/invalidSignedUrl';
+  const notFoundSignedUrl = 'https://s3.mock/notFoundSignedUrl';
 
   const s3ErrorResponse = new Response('Forbidden', { status: 403 });
+  const notFoundErrorResponse = new Response('NotFound', { status: 404 });
 
   beforeAll(async () => {
     fetchMock.mockIf(/.*/, (req) => {
@@ -166,6 +168,7 @@ describe('seekFromS3 unit tests', () => {
 
       if (path.endsWith(validSignedUrl)) return Promise.resolve(result);
       if (path.endsWith(invalidSignedUrl)) return Promise.resolve(s3ErrorResponse);
+      if (path.endsWith(notFoundSignedUrl)) return Promise.resolve(notFoundErrorResponse);
 
       return {
         status: 500,
@@ -176,6 +179,12 @@ describe('seekFromS3 unit tests', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+  });
+
+  it('Should return null when response status is not found', async () => {
+    const finalResult = await seekFromS3(taskName, notFoundSignedUrl);
+
+    expect(finalResult).toBeNull();
   });
 
   it('Should return results correctly', async () => {

--- a/src/utils/work/seekWorkResponse.js
+++ b/src/utils/work/seekWorkResponse.js
@@ -6,6 +6,7 @@ import unpackResult, { decompressUint8Array } from 'utils/work/unpackResult';
 import parseResult from 'utils/work/parseResult';
 import WorkTimeoutError from 'utils/errors/http/WorkTimeoutError';
 import WorkResponseError from 'utils/errors/http/WorkResponseError';
+import httpStatusCodes from 'utils/http/httpStatusCodes';
 
 import { updateBackendStatus } from 'redux/actions/backendStatus';
 
@@ -27,7 +28,9 @@ const getRemainingWorkerStartTime = (creationTimestamp) => {
 
 const seekFromS3 = async (taskName, signedUrl) => {
   const response = await fetch(signedUrl);
-
+  if (response.status === httpStatusCodes.NOT_FOUND) {
+    return null;
+  }
   if (!response.ok) {
     throw new Error(`Error ${response.status}: ${response.text}`, { cause: response });
   }


### PR DESCRIPTION
# Description

When we improved the worker speed, we inadvertently removed a code path. In this code path, when the `seekFromS3` returns a 404, the function itself should catch the error and just return null. This happens for work requests where the response data does not travel through S3 (or via socket) but instead is a cellset update patched through the API. These are the run clustering, run scType for example. 

# Details
#### URL to issue
https://github.com/hms-dbmi-cellenics/issues/issues/73

#### Link to staging deployment URL (or set N/A)
https://ui-ahriman-ui32.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
