### PR TITLE
fix(seekFromS3): returning null on 403 error

### DIFF
--- a/src/__test__/utils/work/seekWorkResponse.test.js
+++ b/src/__test__/utils/work/seekWorkResponse.test.js
@@ -181,8 +181,13 @@ describe('seekFromS3 unit tests', () => {
     jest.clearAllMocks();
   });
 
-  it('Should return null when response status is not found', async () => {
-    const finalResult = await seekFromS3(taskName, notFoundSignedUrl);
+  it('Should return null when response status is not found or forbidden', async () => {
+    let finalResult = await seekFromS3(taskName, notFoundSignedUrl);
+
+    expect(finalResult).toBeNull();
+
+    // returns 403
+    finalResult = await seekFromS3(taskName, invalidSignedUrl);
 
     expect(finalResult).toBeNull();
   });
@@ -201,11 +206,5 @@ describe('seekFromS3 unit tests', () => {
     expect(mockResponsePayload).toEqual(result);
 
     expect(parseResult).toHaveBeenCalledWith('mockUnpackedResult', taskName);
-  });
-
-  it('Should throw an error if fetching returns an error', async () => {
-    await expect(async () => {
-      await seekFromS3(taskName, invalidSignedUrl);
-    }).rejects.toThrow(new Error(`Error ${s3ErrorResponse.status}: ${s3ErrorResponse.text}`, { cause: s3ErrorResponse }));
   });
 });

--- a/src/utils/plotUtils.js
+++ b/src/utils/plotUtils.js
@@ -54,6 +54,7 @@ const renderCellSetColors = (rootKey, cellSetHierarchy, cellSetProperties) => {
 };
 
 const colorByGeneExpression = (truncatedExpression, min, max = 4) => {
+  // eslint-disable-next-line no-param-reassign
   if (max === 0) max = 4;
 
   const scaleFunction = vega.scale('sequential')()

--- a/src/utils/work/seekWorkResponse.js
+++ b/src/utils/work/seekWorkResponse.js
@@ -28,7 +28,16 @@ const getRemainingWorkerStartTime = (creationTimestamp) => {
 
 const seekFromS3 = async (taskName, signedUrl) => {
   const response = await fetch(signedUrl);
-  if (response.status === httpStatusCodes.NOT_FOUND) {
+
+  // some WorkRequests like scType and runClustering do not upload data to S3
+  // (nor return it via socket) instead they patch the cellsets through the API.
+  // In those cases the workResults will not exist, and it's fine because data will
+  // be updated through the cellsets.
+  // the forbidden (in addition to the not found) is required because of how signed URLs work
+  //  when you try to download a file from a signedUrl that doesn't exist you get a 403 forbidden
+  // because the user is not authorized to access a file that does not exist
+  if (response.status === httpStatusCodes.NOT_FOUND
+    || response.status === httpStatusCodes.FORBIDDEN) {
     return null;
   }
   if (!response.ok) {


### PR DESCRIPTION
# Description
Only returning null on 404 does not work. The problem is that using signed URLs will return a 403 when it doesn't exist. This is why:

> When you're using signed URLs in Amazon S3, the behavior you're experiencing, where a 403 (Forbidden) error occurs when the file doesn't exist, is expected. Let me explain why this happens:
> 
> Signed URLs are Based on the Object's Key: When you generate a signed URL for an object in Amazon S3, the URL is based on the object's key (path) and includes a signature. This signature is a cryptographic token that proves the URL is authorized to access a specific resource. If the object with the given key doesn't exist, the signature is still valid because it's based on the key, not the existence of the object.
> 
> Signature Validates Access to a Non-existent Object: When you make a request using the signed URL, Amazon S3 checks the signature to determine if the request is authorized. Since the signature is valid (it matches the key and other parameters), S3 allows the request to go through. However, when it looks for the object with that key and doesn't find it, it returns a 403 (Forbidden) error because you are not authorized to access an object that doesn't exist.
> 

so when we get the 403 because the file does not exist in the work requests where the data is sent via cellsets update to the API (scType, run clustering, etc...) we should just ignore it (as we did before the worker refactor improvements).

# Details
#### URL to issue
https://github.com/hms-dbmi-cellenics/issues/issues/73


#### Link to staging deployment URL (or set N/A)
https://ui-ahriman-sctype.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
