### PR TITLE
Remove reduction method identifier from embedding before plotting

### DIFF
--- a/src/redux/actions/embedding/loadEmbedding.js
+++ b/src/redux/actions/embedding/loadEmbedding.js
@@ -47,12 +47,13 @@ const loadEmbedding = (
     const data = await fetchWork(
       experimentId, body, getState, dispatch, { timeout },
     );
+    const modifiedData = data.slice(1);
     return dispatch({
       type: EMBEDDINGS_LOADED,
       payload: {
         experimentId,
         embeddingType,
-        data,
+        data: modifiedData,
       },
     });
   } catch (error) {


### PR DESCRIPTION
# Description
When downloading the rds file that contains the Seurat object, the dimensionality reduction name is invariably set to "umap" even in instances where t-SNE has been applied.
When the embeddings are calculated, converted to json, and sent to S3, the information on which method was used to generate them (which is in the column names) is lost. [The worker PR](https://github.com/hms-dbmi-cellenics/worker/pull/350) adds a first row as a reduction method identifier, which is then used when downloading the rds object to assign the correct reduction name.
This PR removes the reduction method identifier from the embeddings before generating the plot.

# Details
#### URL to issue
https://github.com/hms-dbmi-cellenics/issues/issues/89

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/worker/pull/350

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
