### PR TITLE
UI improvements

### DIFF
--- a/src/__test__/components/data-exploration/cell-sets-tool/CellSetsTool.test.jsx
+++ b/src/__test__/components/data-exploration/cell-sets-tool/CellSetsTool.test.jsx
@@ -770,7 +770,7 @@ describe('AnnotateClustersTool', () => {
   it('Renders correctly', async () => {
     // Check displays correct text
     screen.getByText(/ScType/);
-    screen.getByText(/Tissue Type/);
+    screen.getByText(/Tissue type/);
     screen.getByText(/Species/);
     screen.getByText(/Compute/);
 

--- a/src/__test__/components/data-exploration/cell-sets-tool/HideSelectedCellSetsOperation.test.jsx
+++ b/src/__test__/components/data-exploration/cell-sets-tool/HideSelectedCellSetsOperation.test.jsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import { CELL_SETS_HIDE, CELL_SETS_UNHIDE } from 'redux/actionTypes/cellSets';
+import initialState from 'redux/reducers/cellSets/initialState';
+import HideSelectedCellSetsOperation from 'components/data-exploration/cell-sets-tool/HideSelectedCellSetsOperation';
+import '__test__/test-utils/setupTests';
+
+const mockStore = configureMockStore([thunk]);
+
+const HIDDEN_KEY_1 = 'hidden-key-1';
+const HIDDEN_KEY_2 = 'hidden-key-2';
+const VISIBLE_KEY = 'visible-key';
+
+describe('HideSelectedCellSetsOperation', () => {
+  test('renders correctly', () => {
+    const store = mockStore({
+      cellSets: {
+        ...initialState,
+        hidden: new Set([HIDDEN_KEY_1, HIDDEN_KEY_2]),
+      },
+    });
+
+    const component = mount(
+      <Provider store={store}>
+        <HideSelectedCellSetsOperation selectedCellSetKeys={[VISIBLE_KEY]} />
+      </Provider>,
+    );
+
+    const tooltip = component.find('Tooltip');
+    expect(tooltip.length).toEqual(1);
+
+    const button = component.find('Tooltip Button');
+    expect(button.length).toEqual(1);
+  });
+
+  test('renders hide icon and tooltip when selected cell sets are not hidden', () => {
+    const store = mockStore({
+      cellSets: {
+        ...initialState,
+        hidden: new Set([HIDDEN_KEY_1, HIDDEN_KEY_2]),
+      },
+    });
+
+    const component = mount(
+      <Provider store={store}>
+        <HideSelectedCellSetsOperation selectedCellSetKeys={[VISIBLE_KEY]} />
+      </Provider>,
+    );
+
+    const tooltip = component.find('Tooltip');
+    expect(tooltip.props().title).toContain('Hide selected cell sets');
+
+    const button = component.find('Button');
+    expect(button.props()['aria-label']).toContain('Hide selected cell sets');
+  });
+
+  test('renders show icon and tooltip when all selected cell sets are hidden', () => {
+    const store = mockStore({
+      cellSets: {
+        ...initialState,
+        hidden: new Set([HIDDEN_KEY_1, HIDDEN_KEY_2]),
+      },
+    });
+
+    const component = mount(
+      <Provider store={store}>
+        <HideSelectedCellSetsOperation selectedCellSetKeys={[HIDDEN_KEY_1, HIDDEN_KEY_2]} />
+      </Provider>,
+    );
+
+    const tooltip = component.find('Tooltip');
+    expect(tooltip.props().title).toContain('Show selected cell sets');
+
+    const button = component.find('Button');
+    expect(button.props()['aria-label']).toContain('Show selected cell sets');
+  });
+
+  test('renders hide icon and tooltip when only some selected cell sets are hidden', () => {
+    const store = mockStore({
+      cellSets: {
+        ...initialState,
+        hidden: new Set([HIDDEN_KEY_1, HIDDEN_KEY_2]),
+      },
+    });
+
+    const component = mount(
+      <Provider store={store}>
+        <HideSelectedCellSetsOperation selectedCellSetKeys={[HIDDEN_KEY_1, VISIBLE_KEY]} />
+      </Provider>,
+    );
+
+    const tooltip = component.find('Tooltip');
+    expect(tooltip.props().title).toContain('Hide selected cell sets');
+
+    const button = component.find('Button');
+    expect(button.props()['aria-label']).toContain('Hide selected cell sets');
+  });
+
+  test('clicking button when all visible dispatches hide actions for all selected sets', () => {
+    const store = mockStore({
+      cellSets: {
+        ...initialState,
+        hidden: new Set([HIDDEN_KEY_1, HIDDEN_KEY_2]),
+      },
+    });
+
+    const component = mount(
+      <Provider store={store}>
+        <HideSelectedCellSetsOperation selectedCellSetKeys={[VISIBLE_KEY, 'another-visible']} />
+      </Provider>,
+    );
+
+    const button = component.find('Button');
+    button.simulate('click');
+
+    expect(store.getActions().length).toEqual(2);
+
+    const action1 = store.getActions()[0];
+    expect(action1.type).toBe(CELL_SETS_HIDE);
+
+    const action2 = store.getActions()[1];
+    expect(action2.type).toBe(CELL_SETS_HIDE);
+  });
+
+  test('clicking button when all hidden dispatches unhide actions for all selected sets', () => {
+    const store = mockStore({
+      cellSets: {
+        ...initialState,
+        hidden: new Set([HIDDEN_KEY_1, HIDDEN_KEY_2]),
+      },
+    });
+
+    const component = mount(
+      <Provider store={store}>
+        <HideSelectedCellSetsOperation selectedCellSetKeys={[HIDDEN_KEY_1, HIDDEN_KEY_2]} />
+      </Provider>,
+    );
+
+    const button = component.find('Button');
+    button.simulate('click');
+
+    expect(store.getActions().length).toEqual(2);
+
+    const action1 = store.getActions()[0];
+    expect(action1.type).toBe(CELL_SETS_UNHIDE);
+
+    const action2 = store.getActions()[1];
+    expect(action2.type).toBe(CELL_SETS_UNHIDE);
+  });
+
+  test('clicking button when partially hidden dispatches hide and unhide actions', () => {
+    const store = mockStore({
+      cellSets: {
+        ...initialState,
+        hidden: new Set([HIDDEN_KEY_1, HIDDEN_KEY_2]),
+      },
+    });
+
+    const component = mount(
+      <Provider store={store}>
+        <HideSelectedCellSetsOperation selectedCellSetKeys={[HIDDEN_KEY_1, VISIBLE_KEY]} />
+      </Provider>,
+    );
+
+    const button = component.find('Button');
+    button.simulate('click');
+
+    expect(store.getActions().length).toEqual(2);
+
+    // First action for HIDDEN_KEY_1 (was hidden, should unhide)
+    const action1 = store.getActions()[0];
+    expect(action1.type).toBe(CELL_SETS_UNHIDE);
+
+    // Second action for VISIBLE_KEY (was visible, should hide)
+    const action2 = store.getActions()[1];
+    expect(action2.type).toBe(CELL_SETS_HIDE);
+  });
+});

--- a/src/__test__/components/data-exploration/differential-expression-tool/DiffExprManager-regression-load-on-second-render.test.jsx
+++ b/src/__test__/components/data-exploration/differential-expression-tool/DiffExprManager-regression-load-on-second-render.test.jsx
@@ -91,6 +91,11 @@ const storeState = {
       advancedFilters: [],
     },
   },
+  experimentSettings: {
+    info: {
+      experimentName: 'experiment',
+    },
+  },
   backendStatus,
 };
 

--- a/src/__test__/components/data-exploration/differential-expression-tool/DiffExprManager.test.jsx
+++ b/src/__test__/components/data-exploration/differential-expression-tool/DiffExprManager.test.jsx
@@ -30,6 +30,11 @@ const emptyState = {
     ...getInitialState(),
     focused: undefined,
   },
+  experimentSettings: {
+    info: {
+      experimentName: 'experiment',
+    },
+  },
 };
 
 const experimentId = '1234';
@@ -88,6 +93,11 @@ const filledState = {
         },
       },
       advancedFilters: [],
+    },
+  },
+  experimentSettings: {
+    info: {
+      experimentName: 'experiment',
     },
   },
   backendStatus,

--- a/src/__test__/components/data-exploration/differential-expression-tool/DiffExprResults.test.jsx
+++ b/src/__test__/components/data-exploration/differential-expression-tool/DiffExprResults.test.jsx
@@ -100,6 +100,11 @@ const resultState = {
       advancedFilters: [],
     },
   },
+  experimentSettings: {
+    info: {
+      experimentName: 'experiment',
+    },
+  },
   backendStatus,
 };
 
@@ -162,14 +167,14 @@ describe('DiffExprResults', () => {
     const spin = component.find(Loader);
     expect(spin.length).toEqual(0);
     expect(table.length).toEqual(1);
-    expect(table.getElement().props.columns.length).toEqual(7);
+    // auc column present, so p_val_adj is filtered out
+    expect(table.getElement().props.columns.length).toEqual(6);
     expect(table.getElement().props.columns[0].key).toEqual('lookup');
     expect(table.getElement().props.columns[1].key).toEqual('gene_names');
     expect(table.getElement().props.columns[2].key).toEqual('logFC');
-    expect(table.getElement().props.columns[3].key).toEqual('p_val_adj');
-    expect(table.getElement().props.columns[4].key).toEqual('pct_1');
-    expect(table.getElement().props.columns[5].key).toEqual('pct_2');
-    expect(table.getElement().props.columns[6].key).toEqual('auc');
+    expect(table.getElement().props.columns[3].key).toEqual('pct_1');
+    expect(table.getElement().props.columns[4].key).toEqual('pct_2');
+    expect(table.getElement().props.columns[5].key).toEqual('auc');
 
     expect(table.getElement().props.dataSource.length).toEqual(5);
     expect(table.getElement().props.data.length).toEqual(5);
@@ -188,12 +193,12 @@ describe('DiffExprResults', () => {
     );
 
     const table = component.find('Table');
+    // logFC column (now at index 2 with p_val_adj filtered out) should still be sorted descending
     expect(table.getElement().props.columns[1].sortOrder).toEqual(null);
     expect(table.getElement().props.columns[2].sortOrder).toEqual('descend');
     expect(table.getElement().props.columns[3].sortOrder).toEqual(null);
     expect(table.getElement().props.columns[4].sortOrder).toEqual(null);
     expect(table.getElement().props.columns[5].sortOrder).toEqual(null);
-    expect(table.getElement().props.columns[6].sortOrder).toEqual(null);
   });
 
   it('fetches all the genes', async () => {
@@ -284,7 +289,8 @@ describe('DiffExprResults', () => {
 
     const entries = component.find('.ant-table-tbody').children();
 
-    expect(entries.at(1).text()).toEqual('A-1.41.651001000.1');
+    // p_val_adj column is filtered out when auc is present
+    expect(entries.at(1).text()).toEqual('A-1.41001000.1');
     expect(entries).toHaveLength(2);
   });
 
@@ -425,12 +431,12 @@ describe('DiffExprResults', () => {
     );
 
     const table = component.find('Table');
-    expect(table.getElement().props.columns.length).toEqual(5);
+    // pct_1 and pct_2 are not present in partial data, and auc is present so p_val_adj is filtered out
+    expect(table.getElement().props.columns.length).toEqual(4);
     expect(table.getElement().props.columns[0].key).toEqual('lookup');
     expect(table.getElement().props.columns[1].key).toEqual('gene_names');
     expect(table.getElement().props.columns[2].key).toEqual('logFC');
-    expect(table.getElement().props.columns[3].key).toEqual('p_val_adj');
-    expect(table.getElement().props.columns[4].key).toEqual('auc');
+    expect(table.getElement().props.columns[3].key).toEqual('auc');
   });
 
   it('Data without corresponding columns are not shown', async () => {
@@ -447,14 +453,14 @@ describe('DiffExprResults', () => {
 
     const table = component.find('Table');
 
-    expect(table.getElement().props.columns.length).toEqual(7);
+    // auc column present, so p_val_adj is filtered out
+    expect(table.getElement().props.columns.length).toEqual(6);
     expect(table.getElement().props.columns[0].key).toEqual('lookup');
     expect(table.getElement().props.columns[1].key).toEqual('gene_names');
     expect(table.getElement().props.columns[2].key).toEqual('logFC');
-    expect(table.getElement().props.columns[3].key).toEqual('p_val_adj');
-    expect(table.getElement().props.columns[4].key).toEqual('pct_1');
-    expect(table.getElement().props.columns[5].key).toEqual('pct_2');
-    expect(table.getElement().props.columns[6].key).toEqual('auc');
+    expect(table.getElement().props.columns[3].key).toEqual('pct_1');
+    expect(table.getElement().props.columns[4].key).toEqual('pct_2');
+    expect(table.getElement().props.columns[5].key).toEqual('auc');
   });
 
   it('The pathway analysis button is available', () => {
@@ -472,5 +478,85 @@ describe('DiffExprResults', () => {
     // Pathway analysis button should be present
     const pathwayButton = buttons.filterWhere(btn => btn.text() === 'Pathway analysis');
     expect(pathwayButton.length).toEqual(1);
+  });
+
+  it('CSV export button renders correctly and is enabled with data', () => {
+    const component = mount(
+      <Provider store={withResultStore}>
+        <DiffExprResults
+          experimentId={experimentId}
+          onGoBack={jest.fn()}
+          width={100}
+          height={200}
+        />
+      </Provider>,
+    );
+
+    // CSV export button should be present and enabled
+    const buttons = component.find('Button');
+    const csvButton = buttons.filterWhere(btn => btn.text() === 'Export as CSV');
+    expect(csvButton.length).toEqual(1);
+    expect(csvButton.props().disabled).toEqual(false);
+
+    // Check CSVLink is present with correct filename
+    const csvLink = component.find('CSVLink');
+    expect(csvLink.length).toEqual(1);
+    const expectedFilename = 'experiment-cluster_a_vs_cluster_b_in_New_Cluster.csv';
+    expect(csvLink.props().filename).toEqual(expectedFilename);
+  });
+
+  it('CSV export button is disabled when there is no data', () => {
+    const component = mount(
+      <Provider store={noResultStore}>
+        <DiffExprResults
+          experimentId={experimentId}
+          onGoBack={jest.fn()}
+          width={100}
+          height={200}
+        />
+      </Provider>,
+    );
+
+    const buttons = component.find('Button');
+    const csvButton = buttons.filterWhere(btn => btn.text() === 'Export as CSV');
+    expect(csvButton.length).toEqual(1);
+    expect(csvButton.props().disabled).toEqual(true);
+  });
+
+  it('CSV export data excludes _row field and includes all gene data', () => {
+    const component = mount(
+      <Provider store={withResultStore}>
+        <DiffExprResults
+          experimentId={experimentId}
+          onGoBack={jest.fn()}
+          width={100}
+          height={200}
+        />
+      </Provider>,
+    );
+
+    const csvLink = component.find('CSVLink');
+    const csvData = csvLink.props().data;
+
+    // Verify data is returned
+    expect(csvData.length).toBeGreaterThan(0);
+
+    // Verify _row field is not present in CSV data
+    csvData.forEach((row) => {
+      expect(row).not.toHaveProperty('_row');
+      // Verify expected fields are present
+      expect(row).toHaveProperty('gene_names');
+      expect(row).toHaveProperty('logFC');
+      expect(row).toHaveProperty('p_val');
+    });
+
+    // Verify it matches the input data (minus _row field)
+    expect(csvData.length).toEqual(mockGeneExpressionData.length);
+    csvData.forEach((csvRow, idx) => {
+      // Each row should match the original data without the _row field
+      Object.keys(csvRow).forEach((key) => {
+        expect(csvRow[key]).toEqual(mockGeneExpressionData[idx][key]);
+      });
+    });
   });
 });

--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -1,12 +1,19 @@
 import PropTypes from 'prop-types';
-import { ClipLoader, BounceLoader } from 'react-spinners';
-import { Typography } from 'antd';
+import { BounceLoader } from 'react-spinners';
+import { Typography, Spin } from 'antd';
 import useSWR from 'swr';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import fetchAPI from 'utils/http/fetchAPI';
+import colors from 'utils/styling/colors';
 
 const { Text } = Typography;
+
+const spinnerStyles = `
+  .loader-spinner .ant-spin-dot-item {
+    background-color: ${colors.darkRed};
+  }
+`;
 
 const slowLoad = () => (
   <>
@@ -37,11 +44,9 @@ const fastLoad = (message) => (
     display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
   }}
   >
+    <style>{spinnerStyles}</style>
     <div style={{ padding: 25 }}>
-      <ClipLoader
-        size={50}
-        color='#8f0b10'
-      />
+      <Spin size='large' className='loader-spinner' />
     </div>
     <p style={{ textAlign: 'center' }}>
       <Text>

--- a/src/components/data-exploration/cell-sets-tool/AnnotateClustersTool.jsx
+++ b/src/components/data-exploration/cell-sets-tool/AnnotateClustersTool.jsx
@@ -66,7 +66,7 @@ const AnnotateClustersTool = ({ experimentId, onRunAnnotation }) => {
   const [species, setSpecies] = useState(null);
 
   return (
-    <Space direction='vertical'>
+    <Space direction='vertical' size='large' style={{ width: '100%' }}>
       <Radio.Group>
         <Tooltip title={scTypeTooltipText}>
           <Radio>ScType</Radio>
@@ -74,12 +74,14 @@ const AnnotateClustersTool = ({ experimentId, onRunAnnotation }) => {
       </Radio.Group>
 
       <Space direction='vertical' style={{ width: '100%' }}>
-        Tissue Type:
+        Tissue type:
         <Select
           options={tissueOptions.map((option) => ({ label: option, value: option }))}
           value={tissue}
           placeholder='Select a tissue type'
           onChange={setTissue}
+          style={{ width: '100%' }}
+          size='small'
         />
       </Space>
 
@@ -90,6 +92,8 @@ const AnnotateClustersTool = ({ experimentId, onRunAnnotation }) => {
           value={species}
           placeholder='Select a species'
           onChange={setSpecies}
+          style={{ width: '100%' }}
+          size='small'
         />
       </Space>
 
@@ -99,7 +103,7 @@ const AnnotateClustersTool = ({ experimentId, onRunAnnotation }) => {
           onRunAnnotation();
         }}
         disabled={_.isNil(tissue) || _.isNil(species)}
-        style={{ marginTop: '20px' }}
+        size='small'
       >
         Compute
       </Button>

--- a/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
+++ b/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
@@ -14,6 +14,7 @@ import {
 
 import SubsetCellSetsOperation from 'components/data-exploration/cell-sets-tool/SubsetCellSetsOperation';
 import CellSetOperation from 'components/data-exploration/cell-sets-tool/CellSetOperation';
+import HideSelectedCellSetsOperation from 'components/data-exploration/cell-sets-tool/HideSelectedCellSetsOperation';
 import PlatformError from 'components/PlatformError';
 import HierarchicalTree from 'components/data-exploration/hierarchical-tree/HierarchicalTree';
 import AnnotateClustersTool from 'components/data-exploration/cell-sets-tool/AnnotateClustersTool';
@@ -162,6 +163,9 @@ const CellSetsTool = (props) => {
             }}
             ariaLabel='Complement of selected'
             helpTitle='Create new cell set from the complement of the selected sets in the current tab.'
+          />
+          <HideSelectedCellSetsOperation
+            selectedCellSetKeys={selectedCellSetKeys}
           />
           <Text type='primary' id='selectedCellSets'>
             {`${selectedCellsCount} cell${selectedCellsCount === 1 ? '' : 's'} selected`}

--- a/src/components/data-exploration/cell-sets-tool/HideSelectedCellSetsOperation.jsx
+++ b/src/components/data-exploration/cell-sets-tool/HideSelectedCellSetsOperation.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import { Tooltip, Button } from 'antd';
+import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
+
+import { setCellSetHiddenStatus } from 'redux/actions/cellSets';
+import { getCellSets } from 'redux/selectors';
+
+const HideSelectedCellSetsOperation = (props) => {
+  const { selectedCellSetKeys } = props;
+
+  const dispatch = useDispatch();
+  const { hidden: hiddenCellSets } = useSelector(getCellSets());
+
+  const allSelectedHidden = selectedCellSetKeys.every((key) => hiddenCellSets.has(key));
+
+  const onToggleHidden = () => {
+    selectedCellSetKeys.forEach((cellSetKey) => {
+      dispatch(setCellSetHiddenStatus(cellSetKey));
+    });
+  };
+
+  const buttonIcon = allSelectedHidden ? <EyeOutlined /> : <EyeInvisibleOutlined />;
+  const buttonText = allSelectedHidden ? 'Show selected cell sets' : 'Hide selected cell sets';
+
+  return (
+    <Tooltip placement='top' title={buttonText}>
+      <Button
+        type='dashed'
+        icon={buttonIcon}
+        aria-label={buttonText}
+        size='small'
+        onClick={onToggleHidden}
+      />
+    </Tooltip>
+  );
+};
+
+HideSelectedCellSetsOperation.propTypes = {
+  selectedCellSetKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default HideSelectedCellSetsOperation;

--- a/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprCompute.jsx
@@ -230,13 +230,15 @@ const DiffExprCompute = (props) => {
       {selectedComparison === ComparisonType.WITHIN
         ? (
           <>
-            {
-              renderClusterSelectorItem({
-                title: 'Compare cell set:',
-                option: 'cellSet',
-                filterTypes: ['cellSets', 'CLM'],
-              })
-            }
+            <div style={{ marginTop: '16px' }}>
+              {
+                renderClusterSelectorItem({
+                  title: 'Compare cell set:',
+                  option: 'cellSet',
+                  filterTypes: ['cellSets', 'CLM'],
+                })
+              }
+            </div>
 
             {renderClusterSelectorItem({
               title: 'and cell set:',
@@ -252,11 +254,13 @@ const DiffExprCompute = (props) => {
           </>
         ) : (
           <>
-            {renderClusterSelectorItem({
-              title: 'Compare cell set:',
-              option: 'basis',
-              filterTypes: ['cellSets', 'CLM'],
-            })}
+            <div style={{ marginTop: '16px' }}>
+              {renderClusterSelectorItem({
+                title: 'Compare cell set:',
+                option: 'basis',
+                filterTypes: ['cellSets', 'CLM'],
+              })}
+            </div>
 
             {renderClusterSelectorItem({
               title: 'between sample/group:',

--- a/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
@@ -130,7 +130,7 @@ const DiffExprResults = (props) => {
   const cellSetName = getCellSetKey(cellSet);
   const compareWithName = getCellSetKey(compareWith);
   const basisName = getCellSetKey(basis);
-  const csvFileName = `de_${experimentNameClean}_${cellSetName}_vs_${compareWithName}_in_${basisName}_${date}.csv`;
+  const csvFileName = `${experimentNameClean}-${cellSetName}_vs_${compareWithName}_in_${basisName}.csv`;
 
   return (
     <Space direction='vertical' style={{ width: '100%' }}>

--- a/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
@@ -9,11 +9,16 @@ import {
 import { LeftOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 
 import { getCellSets } from 'redux/selectors';
 import loadDifferentialExpression from 'redux/actions/differentialExpression/loadDifferentialExpression';
 
 import GeneTable from 'components/data-exploration/generic-gene-table/GeneTable';
+import ExportAsCSV from 'components/plots/ExportAsCSV';
 
 import AdvancedFilteringModal from 'components/data-exploration/differential-expression-tool/AdvancedFilteringModal';
 import LaunchPathwayAnalysisModal from 'components/data-exploration/differential-expression-tool/LaunchPathwayAnalysisModal';
@@ -34,9 +39,9 @@ const DiffExprResults = (props) => {
     advancedFilters,
   } = useSelector((state) => state.differentialExpression.comparison);
   const { properties } = useSelector(getCellSets());
+  const experimentName = useSelector((state) => state.experimentSettings.info.experimentName);
 
   const [dataShown, setDataShown] = useState(data);
-  const [exportAlert, setExportAlert] = useState(false);
   const [advancedFilteringModalVisible, setAdvancedFilteringModalVisible] = useState(false);
   const [pathwayAnalysisModalVisible, setPathwayAnalysisModalVisible] = useState(false);
   const [columns, setColumns] = useState([]);
@@ -105,23 +110,46 @@ const DiffExprResults = (props) => {
 
   const geneTooltipText = `All genes present in the dataset are shown in the differential expression results table. Note that a gene is typically considered 'differentially expressed' based on established thresholds on FDR and/or log fold change. You should apply your own criteria and thresholds to filter the resulting list of genes using the "Filter results" button.`;
 
+  const getCSVData = () => {
+    if (!dataShown?.length) return [];
+    return dataShown.map((row) => {
+      const { _row, ...csvRow } = row;
+      return csvRow;
+    });
+  };
+
+  const getCellSetKey = (word) => {
+    // Extract the cell set name part (after '/' if present)
+    const key = word?.split('/')[1] || word;
+    // Get the friendly name from properties or use the key as fallback
+    return (properties[key]?.name || _.capitalize(key || '')).replace(/\s+/g, '_');
+  };
+
+  const date = dayjs.utc().format('YYYY-MM-DD-HH-mm-ss');
+  const experimentNameClean = experimentName?.replace(/\s+/g, '_') || 'experiment';
+  const cellSetName = getCellSetKey(cellSet);
+  const compareWithName = getCellSetKey(compareWith);
+  const basisName = getCellSetKey(basis);
+  const csvFileName = `de_${experimentNameClean}_${cellSetName}_vs_${compareWithName}_in_${basisName}_${date}.csv`;
+
   return (
     <Space direction='vertical' style={{ width: '100%' }}>
 
       {/* This is needed so changes to the export alert don't cause the table to re-render. */}
       <Space direction='horizontal'>
-        <Button size='medium' onClick={onGoBack}>
+        <Button size='small' onClick={onGoBack}>
           <span>
             <LeftOutlined />
             Go back
           </span>
         </Button>
-        <Button size='medium' onClick={() => setAdvancedFilteringModalVisible(!advancedFilteringModalVisible)}>
+        <Button size='small' onClick={() => setAdvancedFilteringModalVisible(!advancedFilteringModalVisible)}>
           Filter results
         </Button>
-        <Button size='medium' onClick={() => setPathwayAnalysisModalVisible(!pathwayAnalysisModalVisible)}>
+        <Button size='small' onClick={() => setPathwayAnalysisModalVisible(!pathwayAnalysisModalVisible)}>
           Pathway analysis
         </Button>
+        <ExportAsCSV data={getCSVData()} filename={csvFileName} disabled={!dataShown?.length} />
       </Space>
       {advancedFilteringModalVisible && (
         <AdvancedFilteringModal

--- a/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
@@ -4,16 +4,12 @@ import {
   useDispatch,
 } from 'react-redux';
 import {
-  Space, Button, Alert, Tooltip,
+  Space, Button, Tooltip,
 } from 'antd';
-import { DownloadOutlined, LeftOutlined } from '@ant-design/icons';
+import { LeftOutlined } from '@ant-design/icons';
 import { CSVLink } from 'react-csv';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-
-dayjs.extend(utc);
 
 import { getCellSets } from 'redux/selectors';
 import loadDifferentialExpression from 'redux/actions/differentialExpression/loadDifferentialExpression';
@@ -125,7 +121,6 @@ const DiffExprResults = (props) => {
     return (properties[key]?.name || _.capitalize(key || '')).replace(/\s+/g, '_');
   };
 
-  const date = dayjs.utc().format('YYYY-MM-DD-HH-mm-ss');
   const experimentNameClean = experimentName?.replace(/\s+/g, '_') || 'experiment';
   const cellSetName = getCellSetKey(cellSet);
   const compareWithName = getCellSetKey(compareWith);

--- a/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
@@ -161,7 +161,7 @@ const DiffExprResults = (props) => {
         loadData={loadData}
         extraOptions={null}
         geneColumnTooltipText={geneTooltipText}
-        geneColumnWidth="100px"
+        geneColumnWidth={columns.length < 4 ? '150px' : '100px'}
       />
       {
         pathwayAnalysisModalVisible && (
@@ -177,10 +177,12 @@ const DiffExprResults = (props) => {
 };
 
 const formatDecimal = (value, decimals) => {
+  if (value === undefined || value === null) return '';
   return parseFloat(value).toFixed(decimals).replace(/\.?0+$/, '');
 };
 
 const formatFDR = (value) => {
+  if (value === undefined || value === null) return '';
   const num = parseFloat(value);
 
   // If number is very small, use exponential notation with 1 decimal

--- a/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
@@ -6,7 +6,8 @@ import {
 import {
   Space, Button, Alert, Tooltip,
 } from 'antd';
-import { LeftOutlined } from '@ant-design/icons';
+import { DownloadOutlined, LeftOutlined } from '@ant-design/icons';
+import { CSVLink } from 'react-csv';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import dayjs from 'dayjs';
@@ -18,7 +19,6 @@ import { getCellSets } from 'redux/selectors';
 import loadDifferentialExpression from 'redux/actions/differentialExpression/loadDifferentialExpression';
 
 import GeneTable from 'components/data-exploration/generic-gene-table/GeneTable';
-import ExportAsCSV from 'components/plots/ExportAsCSV';
 
 import AdvancedFilteringModal from 'components/data-exploration/differential-expression-tool/AdvancedFilteringModal';
 import LaunchPathwayAnalysisModal from 'components/data-exploration/differential-expression-tool/LaunchPathwayAnalysisModal';
@@ -55,13 +55,13 @@ const DiffExprResults = (props) => {
   useEffect(() => {
     if (!data.length || !Object.keys(properties).length) return;
     let cols = buildColumns(data);
-    // Remove FDR column if it's a within-group comparison
-    if (comparisonType === 'within') {
+    // Hide FDR column if AUC is present (within-group comparison)
+    if (cols.some(col => col.key === 'auc')) {
       cols = cols.filter(col => col.key !== 'p_val_adj');
     }
     setColumns(cols);
     setDataShown(data);
-  }, [data, properties, comparisonType]);
+  }, [data, properties]);
 
   const loadData = (loadAllState) => {
     geneTableState.current = loadAllState;
@@ -138,10 +138,7 @@ const DiffExprResults = (props) => {
       {/* This is needed so changes to the export alert don't cause the table to re-render. */}
       <Space direction='horizontal'>
         <Button size='small' onClick={onGoBack}>
-          <span>
-            <LeftOutlined />
-            Go back
-          </span>
+          <LeftOutlined />
         </Button>
         <Button size='small' onClick={() => setAdvancedFilteringModalVisible(!advancedFilteringModalVisible)}>
           Filter results
@@ -149,7 +146,15 @@ const DiffExprResults = (props) => {
         <Button size='small' onClick={() => setPathwayAnalysisModalVisible(!pathwayAnalysisModalVisible)}>
           Pathway analysis
         </Button>
-        <ExportAsCSV data={getCSVData()} filename={csvFileName} disabled={!dataShown?.length} />
+        <CSVLink data={getCSVData()} filename={csvFileName}>
+          <Button
+            size='small'
+            disabled={!dataShown?.length}
+            onClick={(e) => e.stopPropagation()}
+          >
+            Export as CSV
+          </Button>
+        </CSVLink>
       </Space>
       {advancedFilteringModalVisible && (
         <AdvancedFilteringModal

--- a/src/components/data-processing/FilterResultTable.jsx
+++ b/src/components/data-processing/FilterResultTable.jsx
@@ -11,8 +11,8 @@ const FilterResultTable = (props) => {
     // Meanwhile, this data for this table is an object. So if tableData is an array
     // That means table data does not exist
     if (Array.isArray(tableData)
-        || !tableData?.after
-        || !tableData?.before
+      || !tableData?.after
+      || !tableData?.before
     ) {
       return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />;
     }
@@ -30,7 +30,7 @@ const FilterResultTable = (props) => {
     const percentChanged = (number, total, decimalPoints = 2) => {
       const ratio = Math.round((number / total) * (10 ** decimalPoints)) / (10 ** decimalPoints);
       const percent = ratio * 100;
-      const fixedDecimal = percent.toFixed(3);
+      const fixedDecimal = percent.toFixed(1);
       return fixedDecimal > 0 ? `+${fixedDecimal}` : `${fixedDecimal}`;
     };
 
@@ -45,24 +45,27 @@ const FilterResultTable = (props) => {
     const columns = [
       {
         fixed: 'left',
-        title: 'Statistics',
+        title: 'Statistic',
         dataIndex: 'title',
         key: 'title',
       },
       {
-        title: '# before',
+        title: 'Before',
         dataIndex: 'before',
         key: 'before',
+        align: 'right',
       },
       {
-        title: '# after',
+        title: 'After',
         dataIndex: 'after',
         key: 'after',
+        align: 'right',
       },
       {
-        title: '% changed',
+        title: 'Change (%)',
         dataIndex: 'percentChanged',
         key: 'percentChanged',
+        align: 'right',
       },
     ];
 


### PR DESCRIPTION
# Description
This pull request introduces several UI and feature improvements across the data exploration tools, focusing on cell set operations, differential expression results, and general usability. The most significant changes include the addition of hide/show functionality for cell sets, improved CSV export in differential expression results, and various UI refinements for consistency and clarity.

**Cell Set Operations**

* Added a new `HideSelectedCellSetsOperation` component, allowing users to hide or show selected cell sets with a button in the cell sets tool. The button updates its icon and tooltip depending on the selection, and dispatches the appropriate Redux actions. [[1]](diffhunk://#diff-0634a026947975a2799689198b0af5b253a1c3ac23b0b096a74798c447c465eeR1-R46) [[2]](diffhunk://#diff-6d78dcba4e7b17c967c93b746f7a66a7de210d6ba30c126650da57a85f428b3fR17) [[3]](diffhunk://#diff-6d78dcba4e7b17c967c93b746f7a66a7de210d6ba30c126650da57a85f428b3fR167-R169)
* Comprehensive tests were added for the new hide/show cell sets operation, covering rendering and interaction scenarios.

**Differential Expression Tool**

* Enhanced the differential expression results table with a CSV export feature, generating a file with a descriptive name based on experiment and cell set context. [[1]](diffhunk://#diff-4650fee699a21b3b719fa23ade3f0cbdaf2ac3827b0404d89318a8930e968cc0L9-R16) [[2]](diffhunk://#diff-4650fee699a21b3b719fa23ade3f0cbdaf2ac3827b0404d89318a8930e968cc0R42-L39) [[3]](diffhunk://#diff-4650fee699a21b3b719fa23ade3f0cbdaf2ac3827b0404d89318a8930e968cc0R113-R157)
* Improved table column logic: the FDR column is now hidden when AUC is present (within-group comparison), and gene column width adapts to the number of columns. [[1]](diffhunk://#diff-4650fee699a21b3b719fa23ade3f0cbdaf2ac3827b0404d89318a8930e968cc0L53-R64) [[2]](diffhunk://#diff-4650fee699a21b3b719fa23ade3f0cbdaf2ac3827b0404d89318a8930e968cc0L164-R197)
* Added handling for null/undefined values in number formatting functions to prevent rendering issues.
* Small UI tweaks: all action buttons in the results panel now use a consistent small size, and spacing in the compute panel was improved for clarity. [[1]](diffhunk://#diff-4650fee699a21b3b719fa23ade3f0cbdaf2ac3827b0404d89318a8930e968cc0R113-R157) [[2]](diffhunk://#diff-0d64e9956cdcef21c4abaf0d24df8fc729929bd9e78f0542498e0e84f095dfdbR233-R241) [[3]](diffhunk://#diff-0d64e9956cdcef21c4abaf0d24df8fc729929bd9e78f0542498e0e84f095dfdbR257-R263)

**General UI and Usability**

* Updated the loader spinner to use Ant Design's `Spin` component with custom coloring for improved visual consistency. [[1]](diffhunk://#diff-2a4dc7a419f877f303b78effb3715930d38ce9b4b52df1f05f6dab0d2f8baf72L2-R17) [[2]](diffhunk://#diff-2a4dc7a419f877f303b78effb3715930d38ce9b4b52df1f05f6dab0d2f8baf72R47-R49)
* Refined the Annotate Clusters tool UI: increased spacing, standardized select box sizing, and improved button sizing and labeling for a more polished appearance. [[1]](diffhunk://#diff-46702c4a127b5131d23461e0655ebfcf2482172783f848c4100433277192ac3eL69-R84) [[2]](diffhunk://#diff-46702c4a127b5131d23461e0655ebfcf2482172783f848c4100433277192ac3eR95-R96) [[3]](diffhunk://#diff-46702c4a127b5131d23461e0655ebfcf2482172783f848c4100433277192ac3eL102-R106)
* In the data processing filter results table, improved column titles for clarity and changed percentage formatting to one decimal place, with right-aligned numeric columns for better readability. [[1]](diffhunk://#diff-27c2b93a3f6a3305072339f2f2015604034c6b9d2e682b77aba023f5ce6d7429L33-R33) [[2]](diffhunk://#diff-27c2b93a3f6a3305072339f2f2015604034c6b9d2e682b77aba023f5ce6d7429L48-R68)

# Details
#### URL to issue
N/A
#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.
- [x] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.