### PR TITLE
fix data-processing hard refresh bug

### DIFF
--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -178,10 +178,10 @@ const WrappedApp = ({ Component, pageProps }) => {
 };
 
 /* eslint-disable global-require */
-WrappedApp.getInitialProps = async ({ Component, ctx }) => {
+WrappedApp.getInitialProps = wrapper.getInitialAppProps((store) => async ({ Component, ctx }) => {
   try {
     const {
-      store, req, query, res, err,
+      req, query, res, err,
     } = ctx || {};
 
     // If a render error occurs, NextJS bypasses the normal page rendering
@@ -190,13 +190,6 @@ WrappedApp.getInitialProps = async ({ Component, ctx }) => {
 
     // Do nothing if not server-side
     if (!req) { return { pageProps: {} }; }
-
-    // If store is not available, try to initialize it manually for v8 compatibility
-    let reduxStore = store;
-    if (!reduxStore) {
-      const { makeStore } = (await import('redux/store'));
-      reduxStore = makeStore();
-    }
 
     const pageProps = Component.getInitialProps
       ? await Component.getInitialProps(ctx)
@@ -210,7 +203,7 @@ WrappedApp.getInitialProps = async ({ Component, ctx }) => {
     const { default: getAuthenticationInfo } = (await import('utils/ssr/getAuthenticationInfo'));
     promises.push(getAuthenticationInfo);
 
-    const results = await Promise.all(promises.map((f) => f(ctx, reduxStore)));
+    const results = await Promise.all(promises.map((f) => f(ctx, store)));
     const { amplifyConfig } = results[1];
 
     try {
@@ -221,7 +214,7 @@ WrappedApp.getInitialProps = async ({ Component, ctx }) => {
 
       if (query?.experimentId) {
         const { default: getExperimentInfo } = (await import('utils/ssr/getExperimentInfo'));
-        await getExperimentInfo(ctx, reduxStore, Auth);
+        await getExperimentInfo(ctx, store, Auth);
       }
 
       return { pageProps: { ...pageProps, amplifyConfig } };
@@ -240,7 +233,7 @@ WrappedApp.getInitialProps = async ({ Component, ctx }) => {
     console.error('Error in getInitialProps:', err);
     return { pageProps: {} };
   }
-};
+});
 /* eslint-enable global-require */
 
 WrappedApp.propTypes = {


### PR DESCRIPTION
# Description
Fix React 18 SSR hydration for data-processing page

Use wrapper.getInitialAppProps() for proper Redux state serialization and
client-side HYDRATE action dispatch during Next.js SSR hydration.

Previously, the manual getInitialProps implementation didn't trigger the
HYDRATE action on the client, causing Redux state to be empty during hard
refresh. Server correctly loaded experiment data with 24 samples, but client
received empty sampleIds array due to hydration mismatch.

Changes:
- Wrap getInitialProps with wrapper.getInitialAppProps() callback
- Remove store destructuring from ctx (now passed as wrapper parameter)
- Remove manual store fallback initialization (guaranteed by wrapper)
- Use store parameter directly from wrapper callback

Fixes plots not showing and filters appearing disabled on hard refresh of
data-processing page.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.