### PR TITLE
fallback to louvain if key absent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,8 +280,10 @@ jobs:
           tags: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, steps.ref.outputs.repo-name, steps.ref.outputs.image-tag) }}
           push: true
           provenance: false
-          cache-from: type=gha,scope=${{ github.workflow }}
-          cache-to: type=gha,mode=max,scope=${{ github.workflow }},ignore-error=true
+          # GHA cache (type=gha) disabled: the cache service repeatedly fails with
+          # "failed to reserve cache", which is fatal even with ignore-error=true.
+          # Restore via registry cache (type=registry to a dedicated mutable ECR repo)
+          # if build times become a problem.
 
   deploy:
     name: Deploy to Kubernetes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,11 +268,11 @@ jobs:
 
       - id: setup-buildx
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - id: build-docker-image
         name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,10 +280,8 @@ jobs:
           tags: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, steps.ref.outputs.repo-name, steps.ref.outputs.image-tag) }}
           push: true
           provenance: false
-          # GHA cache (type=gha) disabled: the cache service repeatedly fails with
-          # "failed to reserve cache", which is fatal even with ignore-error=true.
-          # Restore via registry cache (type=registry to a dedicated mutable ECR repo)
-          # if build times become a problem.
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }},ignore-error=true
 
   deploy:
     name: Deploy to Kubernetes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,8 +280,8 @@ jobs:
           tags: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, steps.ref.outputs.repo-name, steps.ref.outputs.image-tag) }}
           push: true
           provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }},ignore-error=true
 
   deploy:
     name: Deploy to Kubernetes

--- a/src/pages/experiments/[experimentId]/plots-and-tables/frequency/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/frequency/index.jsx
@@ -1,6 +1,8 @@
 /* eslint-disable import/no-unresolved */
 /* eslint-disable no-param-reassign */
-import React, { useEffect, useState, useRef } from 'react';
+import React, {
+  useEffect, useState, useMemo,
+} from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
@@ -45,12 +47,28 @@ const FrequencyPlotPage = ({ experimentId }) => {
 
   const cellSets = useSelector(getCellSets());
 
+  // Legacy plot configs can store the cell set's display *name* (e.g. after the
+  // louvain clustering was renamed) rather than its key. Since every lookup here
+  // resolves by key, fall back to 'louvain' when the stored proportionGrouping
+  // doesn't match an existing hierarchy key - otherwise the selector returns
+  // undefined and the plot crashes when reading its children.
+  const proportionGrouping = cellSets.hierarchy?.some(
+    ({ key }) => key === config?.proportionGrouping,
+  )
+    ? config.proportionGrouping
+    : 'louvain';
+
+  const plotConfig = useMemo(
+    () => (config ? { ...config, proportionGrouping } : config),
+    [config, proportionGrouping],
+  );
+
   const [cellSetClusters] = useSelector(
-    getCellSetsHierarchyByKeys([config?.proportionGrouping]),
+    getCellSetsHierarchyByKeys([proportionGrouping]),
   );
 
   const numLegendItems = useSelector(
-    getCellSetsHierarchyByKeys([config?.proportionGrouping]),
+    getCellSetsHierarchyByKeys([proportionGrouping]),
   )[0]?.children?.length;
 
   const experimentName = useSelector((state) => state.experimentSettings.info.experimentName);
@@ -131,7 +149,7 @@ const FrequencyPlotPage = ({ experimentId }) => {
       const entriesForCluster = plotData.filter((entry) => entry.yCellSetKey === cluster.key);
 
       const cellSetName = cellSets.properties[cluster.key].name;
-      const rootCellSetName = cellSets.properties[config.proportionGrouping].name;
+      const rootCellSetName = cellSets.properties[proportionGrouping].name;
       const newEntry = { [rootCellSetName]: cellSetName };
 
       entriesForCluster.forEach((entry) => {
@@ -197,7 +215,7 @@ const FrequencyPlotPage = ({ experimentId }) => {
         <center>
           <FrequencyPlot
             experimentId={experimentId}
-            config={config}
+            config={plotConfig}
             formatCSVData={formatCSVData}
           />
         </center>


### PR DESCRIPTION
# Description
fixes frequency plot where cluster name is stored as key and not resolved (fallback to `louvain`)

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.
- [x] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.