### PR TITLE
Fix cell set keys with slashes

### DIFF
--- a/src/__test__/redux/reducers/differentialExpressionReducer.test.js
+++ b/src/__test__/redux/reducers/differentialExpressionReducer.test.js
@@ -5,6 +5,19 @@ import {
   DIFF_EXPR_LOADING, DIFF_EXPR_LOADED, DIFF_EXPR_ERROR,
   DIFF_EXPR_COMPARISON_TYPE_SET, DIFF_EXPR_COMPARISON_GROUP_SET,
 } from 'redux/actionTypes/differentialExpression';
+import { CELL_CLASS_DELETE, CELL_SETS_LOADED } from 'redux/actionTypes/cellSets';
+
+const stateWithComparison = (group) => ({
+  ...initialState,
+  comparison: {
+    ...initialState.comparison,
+    type: 'between',
+    group: {
+      ...initialState.comparison.group,
+      between: group,
+    },
+  },
+});
 
 describe('differentialExpressionReducer', () => {
   it('Reduces identical state on unknown action', () => expect(
@@ -151,5 +164,52 @@ describe('differentialExpressionReducer', () => {
     };
 
     expect(newState).toEqual(result);
+  });
+
+  it('Clears the selections of a deleted cell class', () => {
+    const newState = differentialExpressionReducer(
+      stateWithComparison({
+        basis: 'annotations/annotation-a',
+        cellSet: 'sample/sample-a',
+        compareWith: 'sample/sample-b',
+      }),
+      {
+        type: CELL_CLASS_DELETE,
+        payload: { experimentId: '1234', key: 'annotations' },
+      },
+    );
+
+    expect(newState.comparison.group.between).toEqual({
+      basis: null,
+      cellSet: 'sample/sample-a',
+      compareWith: 'sample/sample-b',
+    });
+  });
+
+  it('Clears the selections that no longer exist when cell sets are loaded', () => {
+    const newState = differentialExpressionReducer(
+      stateWithComparison({
+        basis: 'louvain/louvain-42',
+        cellSet: 'sample/sample-a',
+        compareWith: 'rest',
+      }),
+      {
+        type: CELL_SETS_LOADED,
+        payload: {
+          experimentId: '1234',
+          data: [
+            { key: 'louvain', children: [{ key: 'louvain-0' }] },
+            { key: 'sample', children: [{ key: 'sample-a' }, { key: 'sample-b' }] },
+          ],
+        },
+      },
+    );
+
+    // The cell set that isn't in the new cell sets is cleared, the others are kept
+    expect(newState.comparison.group.between).toEqual({
+      basis: null,
+      cellSet: 'sample/sample-a',
+      compareWith: 'rest',
+    });
   });
 });

--- a/src/__test__/utils/cellSets/getCellSetKeys.test.js
+++ b/src/__test__/utils/cellSets/getCellSetKeys.test.js
@@ -1,0 +1,35 @@
+import { getCellSetKey, getCellSetClassKey } from 'utils/cellSets/getCellSetKeys';
+
+describe('getCellSetKey', () => {
+  it('Returns the cell set key of a [cellSetClass/]cellSetKey name', () => {
+    expect(getCellSetKey('louvain/louvain-0')).toEqual('louvain-0');
+  });
+
+  it('Returns the whole name if there is no cell set class', () => {
+    expect(getCellSetKey('all')).toEqual('all');
+  });
+
+  it('Keeps the slashes that are part of the cell set key', () => {
+    // Cell set keys can be derived from user facing names, which can contain slashes
+    expect(getCellSetKey('louvain/louvain-Oligodendrocyte (mature/myelinating)'))
+      .toEqual('louvain-Oligodendrocyte (mature/myelinating)');
+  });
+
+  it('Passes arrays and empty values through', () => {
+    expect(getCellSetKey(['louvain-0'])).toEqual(['louvain-0']);
+    expect(getCellSetKey(null)).toEqual(null);
+    expect(getCellSetKey(undefined)).toEqual(undefined);
+  });
+});
+
+describe('getCellSetClassKey', () => {
+  it('Returns the cell set class key', () => {
+    expect(getCellSetClassKey('louvain/louvain-0')).toEqual('louvain');
+    expect(getCellSetClassKey('louvain/louvain-Oligodendrocyte (mature/myelinating)'))
+      .toEqual('louvain');
+  });
+
+  it('Returns the whole name if there is no cell set class', () => {
+    expect(getCellSetClassKey('all')).toEqual('all');
+  });
+});

--- a/src/__test__/utils/differentialExpression/checkCanRunDiffExpr.test.js
+++ b/src/__test__/utils/differentialExpression/checkCanRunDiffExpr.test.js
@@ -1,0 +1,108 @@
+import checkCanRunDiffExpr, { canRunDiffExprResults } from 'utils/extraActionCreators/differentialExpression/checkCanRunDiffExpr';
+
+const enoughCellIds = (start) => new Set(
+  Array.from({ length: 20 }, (unused, idx) => start + idx),
+);
+
+const getCellSets = () => ({
+  hierarchy: [
+    { key: 'louvain', children: [{ key: 'louvain-0' }] },
+    { key: 'sample', children: [{ key: 'sample-a' }, { key: 'sample-b' }] },
+  ],
+  properties: {
+    louvain: { name: 'Louvain clusters', type: 'cellSets', cellIds: new Set() },
+    'louvain-0': { name: 'Cluster 0', cellIds: new Set([...enoughCellIds(0), ...enoughCellIds(100)]) },
+    sample: { name: 'Samples', type: 'metadataCategorical', cellIds: new Set() },
+    'sample-a': { name: 'sample a', cellIds: enoughCellIds(0) },
+    'sample-b': { name: 'sample b', cellIds: enoughCellIds(100) },
+  },
+});
+
+const check = (cellSets, comparisonGroup) => checkCanRunDiffExpr(
+  cellSets.properties,
+  cellSets.hierarchy,
+  { between: comparisonGroup },
+  'between',
+);
+
+describe('checkCanRunDiffExpr', () => {
+  it('Allows a comparison with enough cells in each sample', () => {
+    expect(check(getCellSets(), {
+      basis: 'louvain/louvain-0',
+      cellSet: 'sample/sample-a',
+      compareWith: 'sample/sample-b',
+    })).toEqual(canRunDiffExprResults.INSUFFICIENT_CELLS_WARNING);
+  });
+
+  it('Allows a comparison of a cell set whose key contains a slash', () => {
+    const cellSets = getCellSets();
+    const keyWithSlash = 'louvain-Oligodendrocyte (mature/myelinating)';
+
+    cellSets.hierarchy[0].children = [{ key: keyWithSlash }];
+    cellSets.properties[keyWithSlash] = cellSets.properties['louvain-0'];
+    delete cellSets.properties['louvain-0'];
+
+    expect(check(cellSets, {
+      basis: `louvain/${keyWithSlash}`,
+      cellSet: 'sample/sample-a',
+      compareWith: 'sample/sample-b',
+    })).toEqual(canRunDiffExprResults.INSUFFICIENT_CELLS_WARNING);
+  });
+
+  it('Does not allow a comparison if a selected cell set no longer exists', () => {
+    // Cell sets are replaced when they are reloaded (e.g. after a reprocess or a
+    // re-upload), which can leave selections pointing at cell sets that are gone.
+    const cellSets = getCellSets();
+    delete cellSets.properties['louvain-0'];
+    cellSets.hierarchy[0].children = [];
+
+    expect(check(cellSets, {
+      basis: 'louvain/louvain-0',
+      cellSet: 'sample/sample-a',
+      compareWith: 'sample/sample-b',
+    })).toEqual(canRunDiffExprResults.FALSE);
+
+    expect(check(cellSets, {
+      basis: 'all',
+      cellSet: 'louvain/louvain-0',
+      compareWith: 'sample/sample-b',
+    })).toEqual(canRunDiffExprResults.FALSE);
+
+    expect(check(cellSets, {
+      basis: 'all',
+      cellSet: 'sample/sample-a',
+      compareWith: 'louvain/louvain-0',
+    })).toEqual(canRunDiffExprResults.FALSE);
+  });
+
+  it('Does not allow a comparison if the cell sets are not loaded', () => {
+    expect(check({ properties: {}, hierarchy: [] }, {
+      basis: 'louvain/louvain-0',
+      cellSet: 'sample/sample-a',
+      compareWith: 'sample/sample-b',
+    })).toEqual(canRunDiffExprResults.FALSE);
+  });
+
+  it('Does not reuse the cell id to sample mapping of previously loaded cell sets', () => {
+    const comparisonGroup = {
+      basis: 'louvain/louvain-0',
+      cellSet: 'sample/sample-a',
+      compareWith: 'sample/sample-b',
+    };
+
+    expect(check(getCellSets(), comparisonGroup))
+      .toEqual(canRunDiffExprResults.INSUFFICIENT_CELLS_WARNING);
+
+    // Same cell sets, same number of samples, but all the cells are now in the
+    // second sample, so the first one no longer has enough cells
+    const reloadedCellSets = getCellSets();
+    reloadedCellSets.properties['sample-a'] = { name: 'sample a', cellIds: new Set() };
+    reloadedCellSets.properties['sample-b'] = {
+      name: 'sample b',
+      cellIds: new Set([...enoughCellIds(0), ...enoughCellIds(100)]),
+    };
+
+    expect(check(reloadedCellSets, comparisonGroup))
+      .toEqual(canRunDiffExprResults.INSUFFCIENT_CELLS_ERROR);
+  });
+});

--- a/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
+++ b/src/components/data-exploration/differential-expression-tool/DiffExprResults.jsx
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 
 import { getCellSets } from 'redux/selectors';
+import { getCellSetKey, getCellSetClassKey } from 'utils/cellSets';
 import loadDifferentialExpression from 'redux/actions/differentialExpression/loadDifferentialExpression';
 
 import GeneTable from 'components/data-exploration/generic-gene-table/GeneTable';
@@ -87,7 +88,8 @@ const DiffExprResults = (props) => {
   };
 
   const optionName = (word) => {
-    const [rootGroup, clusterName] = word.split('/');
+    const rootGroup = getCellSetClassKey(word);
+    const clusterName = word.includes('/') ? getCellSetKey(word) : undefined;
 
     let printString = '';
 
@@ -114,17 +116,16 @@ const DiffExprResults = (props) => {
     });
   };
 
-  const getCellSetKey = (word) => {
-    // Extract the cell set name part (after '/' if present)
-    const key = word?.split('/')[1] || word;
+  const getCellSetFileName = (word) => {
+    const key = getCellSetKey(word);
     // Get the friendly name from properties or use the key as fallback
     return (properties[key]?.name || _.capitalize(key || '')).replace(/\s+/g, '_');
   };
 
   const experimentNameClean = experimentName?.replace(/\s+/g, '_') || 'experiment';
-  const cellSetName = getCellSetKey(cellSet);
-  const compareWithName = getCellSetKey(compareWith);
-  const basisName = getCellSetKey(basis);
+  const cellSetName = getCellSetFileName(cellSet);
+  const compareWithName = getCellSetFileName(compareWith);
+  const basisName = getCellSetFileName(basis);
   const csvFileName = `${experimentNameClean}-${cellSetName}_vs_${compareWithName}_in_${basisName}.csv`;
 
   return (

--- a/src/pages/experiments/[experimentId]/plots-and-tables/batch-differential-expression/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/batch-differential-expression/index.jsx
@@ -26,6 +26,7 @@ import { saveAs } from 'file-saver';
 import _ from 'lodash';
 import checkCanRunDiffExpr, { canRunDiffExprResults } from 'utils/extraActionCreators/differentialExpression/checkCanRunDiffExpr';
 import { metadataKeyToName } from 'utils/data-management/metadataUtils';
+import { getCellSetKey } from 'utils/cellSets';
 
 const comparisonTypes = {
   fullList: 'within',
@@ -41,9 +42,9 @@ const comparisonInitialState = {
 
 const cellSetNameFromKey = (properties, key) => {
   // some entries have the parent cell set in the name like sample/213123-asda-2321
-  // the second part after the slash is needed to return the cell set name
-  const keySplitted = key?.split('/')[1] || key;
-  return properties[keySplitted]?.name.replace(/\s+/g, '_') || keySplitted;
+  // the part after the first slash is needed to return the cell set name
+  const cellSetKey = getCellSetKey(key);
+  return properties[cellSetKey]?.name.replace(/\s+/g, '_') || cellSetKey;
 };
 
 const BatchDiffExpression = (props) => {

--- a/src/pages/experiments/[experimentId]/plots-and-tables/dot-plot/index.jsx
+++ b/src/pages/experiments/[experimentId]/plots-and-tables/dot-plot/index.jsx
@@ -33,6 +33,7 @@ import {
 } from 'redux/actions/componentConfig';
 
 import { getCellSets } from 'redux/selectors';
+import { getCellSetKey, getCellSetClassKey } from 'utils/cellSets';
 import { plotNames, plotTypes } from 'utils/constants';
 import PlatformError from 'components/PlatformError';
 
@@ -122,7 +123,8 @@ const DotPlotPage = (props) => {
 
   const hasGroupsToCompare = (baseCluster, filterCluster) => {
     // filterBy has the shape louvain/louvain-1
-    const [filterRootNode, filterKey] = filterCluster.split('/');
+    const filterRootNode = getCellSetClassKey(filterCluster);
+    const filterKey = filterCluster.includes('/') ? getCellSetKey(filterCluster) : undefined;
 
     // If 'All" is chosen for the dropdown,
     // there will always be representation from more than 1 group

--- a/src/redux/actions/componentConfig/getDotPlot.js
+++ b/src/redux/actions/componentConfig/getDotPlot.js
@@ -9,6 +9,7 @@ import {
 import handleError from 'utils/http/handleError';
 import endUserMessages from 'utils/endUserMessages';
 import fetchWork from 'utils/work/fetchWork';
+import { getCellSetKey, getCellSetClassKey } from 'utils/cellSets';
 
 const getClusterNames = (state) => {
   const clusterIds = state.cellSets.hierarchy.reduce(
@@ -58,7 +59,10 @@ const getDotPlot = (
   const clusterNames = getClusterNames(getState());
   const timeout = getTimeoutForWorkerTask(getState(), 'PlotData');
 
-  const [filterGroup, filterKey] = config.selectedPoints.split('/');
+  const filterGroup = getCellSetClassKey(config.selectedPoints);
+  const filterKey = config.selectedPoints.includes('/')
+    ? getCellSetKey(config.selectedPoints)
+    : undefined;
 
   const body = {
     name: 'DotPlot',

--- a/src/redux/reducers/differentialExpression/cellClassDelete.js
+++ b/src/redux/reducers/differentialExpression/cellClassDelete.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-param-reassign */
+import produce from 'immer';
+import { getCellSetClassKey } from 'utils/cellSets';
+
+// Deleting a cell class deletes all the cell sets under it, so any comparison
+// selected from it is left pointing at a cell set that no longer exists.
+const cellClassDelete = produce((draft, action) => {
+  const { key: deletedClassKey } = action.payload;
+
+  Object.values(draft.comparison.group).forEach((comparisonGroup) => {
+    Object.entries(comparisonGroup).forEach(([comparisonKey, comparisonValue]) => {
+      if (getCellSetClassKey(comparisonValue) !== deletedClassKey) return;
+      comparisonGroup[comparisonKey] = null;
+    });
+  });
+});
+
+export default cellClassDelete;

--- a/src/redux/reducers/differentialExpression/cellSetsLoaded.js
+++ b/src/redux/reducers/differentialExpression/cellSetsLoaded.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-param-reassign */
+import produce from 'immer';
+import { getCellSetKey } from 'utils/cellSets';
+
+// Options that don't refer to a cell set, so they are always valid
+const keysWithoutCellSet = ['all', 'rest', 'background'];
+
+const getKeysInTree = (nodes, keys = new Set()) => {
+  if (!nodes) return keys;
+
+  nodes.forEach(({ key, children }) => {
+    keys.add(key);
+    getKeysInTree(children, keys);
+  });
+
+  return keys;
+};
+
+// The comparison selections are kept in redux, so they can outlive the cell sets
+// they point at: cell sets are replaced wholesale whenever they are (re)loaded,
+// e.g. after a reprocess or a re-upload. Clear the selections that no longer
+// exist, otherwise the tool shows a comparison that can't be run (and crashes
+// when checking whether it can).
+const cellSetsLoaded = produce((draft, action) => {
+  const keysInTree = getKeysInTree(action.payload.data);
+
+  Object.values(draft.comparison.group).forEach((comparisonGroup) => {
+    Object.entries(comparisonGroup).forEach(([comparisonKey, comparisonValue]) => {
+      if (!comparisonValue) return;
+
+      const cellSetKey = getCellSetKey(comparisonValue);
+
+      if (Array.isArray(cellSetKey)
+        || keysWithoutCellSet.includes(cellSetKey)
+        || keysInTree.has(cellSetKey)
+      ) return;
+
+      comparisonGroup[comparisonKey] = null;
+    });
+  });
+});
+
+export default cellSetsLoaded;

--- a/src/redux/reducers/differentialExpression/index.js
+++ b/src/redux/reducers/differentialExpression/index.js
@@ -1,4 +1,4 @@
-import { CELL_SETS_DELETE } from 'redux/actionTypes/cellSets';
+import { CELL_SETS_DELETE, CELL_CLASS_DELETE, CELL_SETS_LOADED } from 'redux/actionTypes/cellSets';
 import {
   DIFF_EXPR_LOADING,
   DIFF_EXPR_LOADED,
@@ -16,6 +16,8 @@ import differentialExpressionSetType from 'redux/reducers/differentialExpression
 import differentialExpressionSetGroup from 'redux/reducers/differentialExpression/differentialExpressionSetGroup';
 import differentialExpressionSetGeneOrdering from 'redux/reducers/differentialExpression/differentialExpressionSetOrdering';
 import cellSetsDelete from 'redux/reducers/differentialExpression/cellSetsDelete';
+import cellClassDelete from 'redux/reducers/differentialExpression/cellClassDelete';
+import cellSetsLoaded from 'redux/reducers/differentialExpression/cellSetsLoaded';
 import initialState from 'redux/reducers/differentialExpression/initialState';
 
 const differentialExpressionReducer = (state = initialState, action) => {
@@ -43,6 +45,12 @@ const differentialExpressionReducer = (state = initialState, action) => {
     }
     case CELL_SETS_DELETE: {
       return cellSetsDelete(state, action);
+    }
+    case CELL_CLASS_DELETE: {
+      return cellClassDelete(state, action);
+    }
+    case CELL_SETS_LOADED: {
+      return cellSetsLoaded(state, action);
     }
     default: {
       return state;

--- a/src/utils/cellSets/getCellSetKeys.js
+++ b/src/utils/cellSets/getCellSetKeys.js
@@ -1,6 +1,16 @@
 // Cell sets have the name [cellSetClass/]cellSetKey
 // These are functions to get the keys of the cellSetClass or the cellSet
-const getCellSetKey = (name) => (Array.isArray(name) ? name : name?.split('/')[1] || name);
+// Only the first slash separates the two: a cellSetKey can itself contain
+// slashes, since keys can be derived from user facing names
+// (e.g. `louvain/louvain-Oligodendrocyte (mature/myelinating)`).
+const getCellSetKey = (name) => {
+  if (Array.isArray(name) || !name) return name;
+
+  const separatorIdx = name.indexOf('/');
+
+  return separatorIdx === -1 ? name : name.slice(separatorIdx + 1);
+};
+
 const getCellSetClassKey = (name) => name?.split('/')[0];
 
 export {

--- a/src/utils/extraActionCreators/differentialExpression/checkCanRunDiffExpr.js
+++ b/src/utils/extraActionCreators/differentialExpression/checkCanRunDiffExpr.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 import { ComparisonType } from 'components/data-exploration/differential-expression-tool/DiffExprCompute';
 import { getCellSetKey, getCellSetClassKey } from 'utils/cellSets';
 
@@ -7,22 +5,39 @@ const MIN_NUM_CELLS_IN_GROUP = 10;
 const NUM_SAMPLES_SHOW_ERROR = 1;
 const NUM_SAMPLES_SHOW_WARNING = 2;
 
-const mapCellIdToSample = _.memoize(
-  (sampleKeys, properties) => {
-    const mapping = [];
-    sampleKeys.forEach((key, idx) => {
-      const { cellIds } = properties[key];
-      cellIds.forEach((cellId) => { mapping[cellId] = idx; });
-    });
+let lastSampleCellIdSets = null;
+let lastCellIdToSampleMap = null;
 
-    return mapping;
-  },
-  (sampleKeys) => sampleKeys.length,
-);
+// Building the mapping is O(number of cells), so it is cached between calls.
+// The cache is keyed on the identity of the samples' cellIds themselves: immer
+// keeps untouched cell sets referentially equal, so unrelated edits (renaming,
+// recoloring) reuse the mapping, while cell sets being reloaded (a reprocess,
+// a re-upload) rebuild it. Keying on the number of samples instead would hand
+// back a mapping built from a different experiment's cell ids.
+const mapCellIdToSample = (sampleKeys, properties) => {
+  const sampleCellIdSets = sampleKeys.map((key) => properties[key]?.cellIds);
+
+  const isCached = lastSampleCellIdSets?.length === sampleCellIdSets.length
+    && sampleCellIdSets.every((cellIds, idx) => cellIds === lastSampleCellIdSets[idx]);
+
+  if (isCached) return lastCellIdToSampleMap;
+
+  const mapping = [];
+  sampleCellIdSets.forEach((cellIds, idx) => {
+    if (!cellIds) return;
+
+    cellIds.forEach((cellId) => { mapping[cellId] = idx; });
+  });
+
+  lastSampleCellIdSets = sampleCellIdSets;
+  lastCellIdToSampleMap = mapping;
+
+  return mapping;
+};
 
 const getSampleKeys = (hierarchy) => hierarchy?.find(
   (rootNode) => (rootNode.key === 'sample'),
-)?.children.map((sample) => sample.key);
+)?.children?.map((sample) => sample.key) ?? [];
 
 const checkCanRunDiffExpr = (
   properties,
@@ -43,7 +58,7 @@ const checkCanRunDiffExpr = (
   if (!basis
     || !cellSet
     || !compareWith
-    || !cellIdToSampleMap.length > 0
+    || cellIdToSampleMap.length === 0
   ) {
     return canRunDiffExprResults.FALSE;
   }
@@ -59,8 +74,15 @@ const checkCanRunDiffExpr = (
     }, []);
     basisCellIds = new Set(allCellIds);
   } else {
+    // The selections live in redux and can outlive the cell sets they point at,
+    // e.g. if the cell sets were reloaded (reprocess, re-upload) or the cell
+    // class was deleted. Such a comparison can't be run.
+    if (!properties[basisCellSetKey]) return canRunDiffExprResults.FALSE;
+
     basisCellIds = properties[basisCellSetKey].cellIds;
   }
+
+  if (!properties[cellSetKey]) return canRunDiffExprResults.FALSE;
 
   const cellSetCellIds = Array.from(properties[cellSetKey].cellIds);
 
@@ -69,7 +91,7 @@ const checkCanRunDiffExpr = (
     const parentKey = getCellSetClassKey(cellSet);
 
     const otherGroupKeys = hierarchy.find((obj) => obj.key === parentKey)
-      .children.filter((child) => child.key !== cellSetKey);
+      ?.children.filter((child) => child.key !== cellSetKey) ?? [];
 
     compareWithCellIds = otherGroupKeys.reduce(
       (cumulativeGroupKeys, child) => cumulativeGroupKeys.concat(
@@ -77,6 +99,8 @@ const checkCanRunDiffExpr = (
       ), [],
     );
   } else {
+    if (!properties[compareWithKey]) return canRunDiffExprResults.FALSE;
+
     compareWithCellIds = Array.from(properties[compareWithKey].cellIds);
   }
 

--- a/src/utils/plotSpecs/generateViolinSpec.js
+++ b/src/utils/plotSpecs/generateViolinSpec.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 
+import { getCellSetKey } from 'utils/cellSets';
+
 /* eslint-disable no-param-reassign */
 const generateSpec = (config, plotData) => {
   const numGroups = _.keys(plotData.groups).length;
@@ -483,8 +485,7 @@ const generateData = (
 
   const cells = [];
   if (cellSetToDisplayId && cellSetToDisplayId.includes('/')) {
-    // eslint-disable-next-line prefer-destructuring
-    cellSetToDisplayId = cellSetToDisplayId.split('/')[1];
+    cellSetToDisplayId = getCellSetKey(cellSetToDisplayId);
   }
 
   cellSetsIds.forEach((cellSetId) => {

--- a/src/utils/work/getHeatmapCellOrder.js
+++ b/src/utils/work/getHeatmapCellOrder.js
@@ -1,6 +1,8 @@
 import seedrandom from 'seedrandom';
 import lruMemoize from 'lru-memoize';
 
+import { getCellSetKey, getCellSetClassKey } from 'utils/cellSets';
+
 // ─── Module-level helpers (not exported) ────────────────────────────────────
 
 const getCellClassIds = (key, hierarchy, properties) => {
@@ -284,9 +286,9 @@ const computeHiddenCellSets = (selectedPoints, cellSets) => {
   let hiddenCellSets = Array.from(cellSets.hidden || []);
 
   if (selectedPoints && selectedPoints !== 'All') {
-    const parts = selectedPoints.split('/');
-    if (parts.length === 2) {
-      const [categoryKey, selectedCellSetKey] = parts;
+    if (selectedPoints.includes('/')) {
+      const categoryKey = getCellSetClassKey(selectedPoints);
+      const selectedCellSetKey = getCellSetKey(selectedPoints);
       const categoryRoot = cellSets.hierarchy.find(
         (node) => node.key === categoryKey,
       );


### PR DESCRIPTION
# Description
Selecting a between-groups comparison crashed the differential expression tool with
`Cannot read properties of undefined (reading 'cellIds')` whenever a selected cell set's key
contained a slash, e.g. `louvain/louvain-Oligodendrocyte (mature/myelinating)`. Cell set names
of the form `[cellSetClass/]cellSetKey` were parsed with `split('/')[1]`, which truncated such a
key to one that doesn't exist. `getCellSetKey` now splits on the first slash only, and the six
places that hand-rolled the same split use it: the DE results labels and CSV filename, batch DE
names, the dot plot's "filter by" (both the check and the worker request), the violin plot's
displayed cell set, and the marker heatmap's hidden cell sets.

Two follow-ups in the same area: `checkCanRunDiffExpr` runs during render, so a selection it
can't resolve took the whole page down instead of disabling Compute — it now returns `FALSE`.
And comparison selections are cleared when the cell sets they point at disappear (a cell class
being deleted, or cell sets replaced on load after a reprocess/re-upload); only single cell set
deletions were handled before.

The worker matched `all`/`rest`/`background` as substrings of the cell set name, so name-derived
keys hit the same class of bug — fixed in hms-dbmi-cellenics/worker#383.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.
- [x] All new dependency licenses have been checked for compatibility.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
